### PR TITLE
test: Add script to test submitting job with offchain input to remote node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6089,6 +6089,7 @@ version = "0.0.1"
 dependencies = [
  "abi",
  "alloy",
+ "bincode",
  "clob-node",
  "clob-programs",
  "clob-test-utils",
@@ -6097,6 +6098,10 @@ dependencies = [
  "eip4844",
  "intensity-test-methods",
  "k256",
+ "kairos-trie",
+ "matching-game-core",
+ "matching-game-programs",
+ "matching-game-server",
  "mock-consumer",
  "mock-consumer-methods",
  "proto",

--- a/contracts/script/output/42070/coprocessor_deployment_output.json
+++ b/contracts/script/output/42070/coprocessor_deployment_output.json
@@ -1,7 +1,7 @@
 {
   "addresses": {
-    "coprocessorProxyAdmin": "0x2190018d88dC9a7D0c261e57277636f28Fd2294c",
-    "jobManager": "0x07D00237f3D090677a8cC395d7A233B37D843421",
-    "jobManagerImplementation": "0xB0ce0be267f1B1db9b30CD3E61DF1C6937129A84"
+    "coprocessorProxyAdmin": "0x18Df82C7E422A42D47345Ed86B0E935E9718eBda",
+    "jobManager": "0x3945f611Fe77A51C7F3e1f84709C1a2fDcDfAC5B",
+    "jobManagerImplementation": "0x459C653FaAE6E13b59cf8E005F5f709C7b2c2EB4"
   }
 }

--- a/contracts/script/output/42070/matching_game_deployment_output.json
+++ b/contracts/script/output/42070/matching_game_deployment_output.json
@@ -1,0 +1,5 @@
+{
+  "addresses": {
+    "consumer": "0x5793a71D3eF074f71dCC21216Dbfd5C0e780132c"
+  }
+}

--- a/contracts/script/output/42070/mock_consumer_deployment_output.json
+++ b/contracts/script/output/42070/mock_consumer_deployment_output.json
@@ -1,0 +1,5 @@
+{
+  "addresses": {
+    "consumer": "0x124363b6D0866118A8b6899F2674856618E0Ea4c"
+  }
+}

--- a/crates/scripts/Cargo.toml
+++ b/crates/scripts/Cargo.toml
@@ -35,6 +35,8 @@ serde_json = { workspace = true }
 url = { workspace = true }
 reqwest = { workspace = true }
 tonic-build = { workspace = true }
+kairos-trie = { workspace = true }
+bincode = { workspace = true }
 
 proto = { workspace = true }
 zkvm-executor = { workspace = true }
@@ -45,6 +47,9 @@ clob-node = { workspace = true }
 clob-programs = { workspace = true }
 mock-consumer = { workspace = true }
 mock-consumer-methods = { workspace = true }
+matching-game-programs = { workspace = true }
+matching-game-core = { workspace = true }
+matching-game-server = { workspace = true }
 contracts = { workspace = true }
 intensity-test-methods = { workspace = true }
 eip4844 = { workspace = true }

--- a/crates/scripts/src/node_test.rs
+++ b/crates/scripts/src/node_test.rs
@@ -101,7 +101,7 @@ async fn main() {
     let decoded = hex::decode(OFFCHAIN_SIGNER_PRIVATE_KEY).unwrap();
     let offchain_signer = K256LocalSigner::from_slice(&decoded).unwrap();
 
-    // Test mock consumer job submision flow
+    // Test mock consumer job submission flow
 
     // Get nonce from the mock consumer contract
     let mock_consumer_addr =
@@ -171,7 +171,7 @@ async fn main() {
 
     info!("Job result for mock consumer relayed to anvil with inputs: {:x?}", inputs);
 
-    // Test matching game job submision flow
+    // Test matching game job submission flow
 
     // Get nonce from the matching game consumer contract
     let matching_game_consumer_addr =

--- a/crates/scripts/src/node_test.rs
+++ b/crates/scripts/src/node_test.rs
@@ -152,16 +152,20 @@ async fn main() {
     info!("HTTP Gateway Result for mock consumer: {:?}", get_result_response);
 
     // Wait for the job result to be relayed to anvil
-    let mut inputs = vec![0u8; 32];
+    let mut inputs;
     let fixed_size_job_id: [u8; 32] = job_id.as_slice().try_into().expect("Fixed size array");
-    let get_inputs_call = mock_consumer_contract.getOnchainInputForJob(FixedBytes(fixed_size_job_id));
-    // If the inputs are all zero, then the job is not yet relayed
-    while inputs.iter().all(|&x| x == 0) {
+    let get_inputs_call =
+        mock_consumer_contract.getOnchainInputForJob(FixedBytes(fixed_size_job_id));
+    loop {
         match get_inputs_call.call().await {
             Ok(MockConsumer::getOnchainInputForJobReturn { _0: result }) => {
                 inputs = result.to_vec();
-                if inputs.iter().all(|&x| x == 0) {
+                // If the inputs are all zero, then the job is not yet relayed
+                if result.into_iter().all(|x| x == 0) {
                     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                } else {
+                    // result successfully submitted onchain
+                    break;
                 }
             }
             Err(e) => eprintln!("Error calling getOnchainInputForJob: {:?}", e),
@@ -247,16 +251,20 @@ async fn main() {
     info!("HTTP Gateway Result for matching game: {:?}", get_result_response);
 
     // Wait for the job result to be relayed to anvil
-    let mut inputs = vec![0u8; 32];
+    let mut inputs;
     let fixed_size_job_id: [u8; 32] = job_id.as_slice().try_into().expect("Fixed size array");
-    let get_inputs_call = matching_game_consumer_contract.getOnchainInputForJob(FixedBytes(fixed_size_job_id));
-    // If the inputs are all zero, then the job is not yet relayed
-    while inputs.iter().all(|&x| x == 0) {
+    let get_inputs_call =
+        matching_game_consumer_contract.getOnchainInputForJob(FixedBytes(fixed_size_job_id));
+    loop {
         match get_inputs_call.call().await {
             Ok(MatchingGameConsumer::getOnchainInputForJobReturn { _0: result }) => {
                 inputs = result.to_vec();
-                if inputs.iter().all(|&x| x == 0) {
+                // If the inputs are all zero, then the job is not yet relayed
+                if result.into_iter().all(|x| x == 0) {
                     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                } else {
+                    // result successfully submitted onchain
+                    break;
                 }
             }
             Err(e) => eprintln!("Error calling getOnchainInputForJob: {:?}", e),

--- a/crates/scripts/src/node_test.rs
+++ b/crates/scripts/src/node_test.rs
@@ -153,11 +153,10 @@ async fn main() {
 
     // Wait for the job result to be relayed to anvil
     let mut inputs = vec![0u8; 32];
+    let fixed_size_job_id: [u8; 32] = job_id.as_slice().try_into().expect("Fixed size array");
+    let get_inputs_call = mock_consumer_contract.getOnchainInputForJob(FixedBytes(fixed_size_job_id));
     // If the inputs are all zero, then the job is not yet relayed
     while inputs.iter().all(|&x| x == 0) {
-        let fixed_size_job_id: [u8; 32] = job_id.as_slice().try_into().expect("Fixed size array");
-        let get_inputs_call =
-            mock_consumer_contract.getOnchainInputForJob(FixedBytes(fixed_size_job_id));
         match get_inputs_call.call().await {
             Ok(MockConsumer::getOnchainInputForJobReturn { _0: result }) => {
                 inputs = result.to_vec();
@@ -249,11 +248,10 @@ async fn main() {
 
     // Wait for the job result to be relayed to anvil
     let mut inputs = vec![0u8; 32];
+    let fixed_size_job_id: [u8; 32] = job_id.as_slice().try_into().expect("Fixed size array");
+    let get_inputs_call = matching_game_consumer_contract.getOnchainInputForJob(FixedBytes(fixed_size_job_id));
     // If the inputs are all zero, then the job is not yet relayed
     while inputs.iter().all(|&x| x == 0) {
-        let fixed_size_job_id: [u8; 32] = job_id.as_slice().try_into().expect("Fixed size array");
-        let get_inputs_call =
-            matching_game_consumer_contract.getOnchainInputForJob(FixedBytes(fixed_size_job_id));
         match get_inputs_call.call().await {
             Ok(MatchingGameConsumer::getOnchainInputForJobReturn { _0: result }) => {
                 inputs = result.to_vec();

--- a/crates/scripts/src/node_test.rs
+++ b/crates/scripts/src/node_test.rs
@@ -27,14 +27,14 @@ use std::rc::Rc;
 use test_utils::create_and_sign_offchain_request;
 use tracing::{error, info};
 
-const COPROCESSOR_IP: &str = "34.162.236.254";
+const COPROCESSOR_IP: &str = "";
 const COPROCESSOR_GRPC_PORT: u16 = 50420;
 const COPROCESSOR_HTTP_PORT: u16 = 8080;
 const MOCK_CONSUMER_ADDR: &str = "0x124363b6D0866118A8b6899F2674856618E0Ea4c";
 const MATCHING_GAME_CONSUMER_ADDR: &str = "0x5793a71D3eF074f71dCC21216Dbfd5C0e780132c";
 const OFFCHAIN_SIGNER_PRIVATE_KEY: &str =
     "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
-const ANVIL_IP: &str = "34.162.169.163";
+const ANVIL_IP: &str = "";
 const ANVIL_PORT: u16 = 8545;
 
 type K256LocalSigner = LocalSigner<SigningKey>;

--- a/crates/scripts/src/node_test.rs
+++ b/crates/scripts/src/node_test.rs
@@ -1,4 +1,5 @@
-//! Test the coprocessor node by submitting programs, submitting a job, and getting the result.
+//! Test the coprocessor node by submitting programs, submitting jobs with onchain and offchain
+//! inputs, and getting the result for both.
 
 use abi::StatefulAppOnchainInput;
 use alloy::{


### PR DESCRIPTION
# What

- Deploys `MatchingGameConsumer` contract to devnet
- Adds logic in `node_test.rs` to test submitting a job with offchain input to the remote coprocessor node and verify that the result is successfully posted onto the L1 devnet. This implicitly tests the blob submission flow, since the job result will only be accepted by the `JobManager` if the blob hashes are correct. We use the `MatchingGameConsumer` as an example of a consumer which has a job with offchain input.

# Testing

`cargo run --bin node-test`: Passes
