### PR TITLE
fix: coprocessor-node dockerfile

### DIFF
--- a/.github/workflows/docker-coproc.yml
+++ b/.github/workflows/docker-coproc.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   docker-release:
     name: Docker release to Google Artifact Registry
-    runs-on: ubicloud-standard-16
+    runs-on: ubicloud-standard-30
 
     permissions:
       contents: 'read'

--- a/.github/workflows/docker-coproc.yml
+++ b/.github/workflows/docker-coproc.yml
@@ -2,6 +2,7 @@ name: docker-coproc
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/docker-coproc.yml
+++ b/.github/workflows/docker-coproc.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   docker-release:
     name: Docker release to Google Artifact Registry
-    runs-on: ubicloud-standard-4
+    runs-on: ubicloud-standard-16
 
     permissions:
       contents: 'read'

--- a/.github/workflows/docker-coproc.yml
+++ b/.github/workflows/docker-coproc.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   docker-release:
     name: Docker release to Google Artifact Registry
-    runs-on: ubicloud-standard-30
+    runs-on: ubicloud-standard-16
 
     permissions:
       contents: 'read'

--- a/Dockerfile.coprocessor-node
+++ b/Dockerfile.coprocessor-node
@@ -1,18 +1,22 @@
-FROM us-docker.pkg.dev/infinityvm-core-artifacts/docker/risc0-builder:1.80.1 AS base
+FROM --platform=linux/amd64 rust:slim-bookworm AS base
 WORKDIR /app
 
 COPY . .
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config && \
-apt-get clean && \
-rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y upgrade && \
+  apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  clang \
+  curl \
+  libclang-dev  \
+  libssl-dev \
+  pkg-config \
+  git && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 RUN curl -L https://foundry.paradigm.xyz | bash && ~/.foundry/bin/foundryup
-ENV PATH /root/.foundry/bin:$PATH
-
-FROM base AS builder
-WORKDIR /app
-COPY --from=base /app/. .
-RUN cd contracts && forge build
-RUN cargo build --release --locked --bin coprocessor-node
+ENV PATH=/root/.foundry/bin:$PATH
+RUN cargo build --release --locked --bin ivm-coprocessor-node
 
 FROM debian:bookworm-slim
 WORKDIR /app
@@ -20,7 +24,7 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/target/release/coprocessor-node /usr/local/bin/coprocessor-node
+COPY --from=builder /app/target/release/ivm-coprocessor-node /usr/local/bin/coprocessor-node
 COPY --from=grafana/promtail:3.0.0 /usr/bin/promtail /usr/local/bin
 
 EXPOSE 50069 50420 22

--- a/Dockerfile.coprocessor-node
+++ b/Dockerfile.coprocessor-node
@@ -14,8 +14,13 @@ RUN apt-get update && apt-get -y upgrade && \
   git && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
-RUN curl -L https://foundry.paradigm.xyz | bash && ~/.foundry/bin/foundryup
-ENV PATH=/root/.foundry/bin:$PATH
+# RUN curl -L https://foundry.paradigm.xyz | bash && ~/.foundry/bin/foundryup
+# ENV PATH=/root/.foundry/bin:$PATH
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=base /app/. .
+# RUN cd contracts && forge build
 RUN cargo build --release --locked --bin ivm-coprocessor-node
 
 FROM debian:bookworm-slim

--- a/Dockerfile.coprocessor-node
+++ b/Dockerfile.coprocessor-node
@@ -14,13 +14,10 @@ RUN apt-get update && apt-get -y upgrade && \
   git && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
-# RUN curl -L https://foundry.paradigm.xyz | bash && ~/.foundry/bin/foundryup
-# ENV PATH=/root/.foundry/bin:$PATH
 
 FROM base AS builder
 WORKDIR /app
 COPY --from=base /app/. .
-# RUN cd contracts && forge build
 RUN cargo build --release --locked --bin ivm-coprocessor-node
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
We broke the docker build when we renamed the coprocessor node crate to `ivm-coprocessor-node`. While fixing this I also realized we don't need the risc0 base image since we don't build any risc0 binaries, just the coprocessor-node binary. We also no longer rely on building the contracts at build time, the abi is committed in the crate.

Changes
- Don't install or use foundry
- Don't use a risc0 base image
- Add some apt installs