### PR TITLE
refactor: Rename `zkvm-executor` to `ivm-zkvm-executor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3812,6 +3812,7 @@ dependencies = [
  "ivm-db",
  "ivm-proto",
  "ivm-test-utils",
+ "ivm-zkvm-executor",
  "k256",
  "mock-consumer",
  "prometheus",
@@ -3823,7 +3824,6 @@ dependencies = [
  "tonic-reflection",
  "tracing 0.0.1",
  "tracing 0.1.40",
- "zkvm-executor",
 ]
 
 [[package]]
@@ -3879,6 +3879,20 @@ dependencies = [
  "mock-consumer-sp1",
  "sp1-sdk",
  "thiserror",
+]
+
+[[package]]
+name = "ivm-zkvm-executor"
+version = "0.0.1"
+dependencies = [
+ "alloy",
+ "eip4844",
+ "ivm-abi",
+ "ivm-proto",
+ "ivm-zkvm",
+ "thiserror",
+ "tokio",
+ "tracing 0.1.40",
 ]
 
 [[package]]
@@ -8743,20 +8757,6 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
-]
-
-[[package]]
-name = "zkvm-executor"
-version = "0.0.1"
-dependencies = [
- "alloy",
- "eip4844",
- "ivm-abi",
- "ivm-proto",
- "ivm-zkvm",
- "thiserror",
- "tokio",
- "tracing 0.1.40",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,6 @@ ivm-proto = { path = "crates/sdk/proto" }
 ivm-test-utils = { path = "crates/sdk/test-utils" }
 ivm-zkvm = { path = "crates/zkvm" }
 zkvm-tracing = { package = "tracing", path = "crates/tracing" }
-zkvm-executor = { path = "crates/zkvm-executor" }
+ivm-zkvm-executor = { path = "crates/zkvm-executor" }
 mock-consumer-sp1 = { path = "programs/sp1/mock-consumer" }
 intensity-test-sp1 = { path = "programs/sp1/intensity-test" }

--- a/crates/coprocessor-node/Cargo.toml
+++ b/crates/coprocessor-node/Cargo.toml
@@ -27,7 +27,7 @@ contracts = { workspace = true }
 ivm-abi = { workspace = true }
 ivm-db = { workspace = true }
 ivm-proto = { workspace = true }
-zkvm-executor = { workspace = true }
+ivm-zkvm-executor = { workspace = true }
 zkvm-tracing = { workspace = true }
 eip4844 = { workspace = true }
 

--- a/crates/coprocessor-node/src/cli.rs
+++ b/crates/coprocessor-node/src/cli.rs
@@ -11,10 +11,10 @@ use alloy::{
     signers::local::LocalSigner,
 };
 use clap::{Parser, Subcommand};
+use ivm_zkvm_executor::DEV_SECRET;
 use k256::ecdsa::SigningKey;
 use std::path::PathBuf;
 use tracing::{info, instrument};
-use zkvm_executor::DEV_SECRET;
 
 const ENV_RELAYER_PRIV_KEY: &str = "RELAYER_PRIVATE_KEY";
 const ENV_ZKVM_OPERATOR_PRIV_KEY: &str = "ZKVM_OPERATOR_PRIV_KEY";

--- a/crates/coprocessor-node/src/intake.rs
+++ b/crates/coprocessor-node/src/intake.rs
@@ -9,15 +9,15 @@ use std::sync::Arc;
 use alloy::{hex, primitives::Signature, signers::Signer};
 use ivm_db::{get_elf, get_job, put_elf, put_job, tables::Job};
 use ivm_proto::{JobStatus, JobStatusType, VmType};
+use ivm_zkvm_executor::service::ZkvmExecutorService;
 use reth_db::Database;
-use zkvm_executor::service::ZkvmExecutorService;
 
 /// Errors from job processor
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// Could not create ELF in zkvm executor
     #[error("failed to create ELF in zkvm executor: {0}")]
-    CreateElfFailed(#[from] zkvm_executor::service::Error),
+    CreateElfFailed(#[from] ivm_zkvm_executor::service::Error),
     /// database error
     #[error("database error: {0}")]
     Database(#[from] ivm_db::Error),

--- a/crates/coprocessor-node/src/job_processor.rs
+++ b/crates/coprocessor-node/src/job_processor.rs
@@ -9,11 +9,11 @@ use ivm_db::{
     tables::{ElfWithMeta, Job, RequestType},
 };
 use ivm_proto::{JobStatus, JobStatusType, VmType};
+use ivm_zkvm_executor::service::ZkvmExecutorService;
 use reth_db::Database;
 use std::{marker::Send, sync::Arc, time::Duration};
 use tokio::task::JoinSet;
 use tracing::{error, info};
-use zkvm_executor::service::ZkvmExecutorService;
 
 /// Delay between retrying failed jobs, in milliseconds.m
 const JOB_RETRY_DELAY_MS: u64 = 250;

--- a/crates/coprocessor-node/src/node.rs
+++ b/crates/coprocessor-node/src/node.rs
@@ -13,6 +13,7 @@ use alloy::{eips::BlockNumberOrTag, primitives::Address, signers::local::LocalSi
 use async_channel::{bounded, Receiver, Sender};
 use ivm_db::tables::Job;
 use ivm_proto::coprocessor_node_server::CoprocessorNodeServer;
+use ivm_zkvm_executor::service::ZkvmExecutorService;
 use k256::ecdsa::SigningKey;
 use prometheus::Registry;
 use reth_db::Database;
@@ -22,7 +23,6 @@ use std::{
 };
 use tokio::{task::JoinHandle, try_join};
 use tracing::info;
-use zkvm_executor::service::ZkvmExecutorService;
 
 type K256LocalSigner = LocalSigner<SigningKey>;
 

--- a/crates/zkvm-executor/Cargo.toml
+++ b/crates/zkvm-executor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "zkvm-executor"
+name = "ivm-zkvm-executor"
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# What

- We use the `zkvm-executor` crate in the foundry template now, so we rename it to `ivm-zkvm-executor`
