### PR TITLE
doc: Update book to sp1 and remove line numbers

### DIFF
--- a/book/src/apps/clob.md
+++ b/book/src/apps/clob.md
@@ -27,21 +27,21 @@ The user flow looks like this:
 
 ## Code Overview
 
-The CLOB app contract is [`ClobConsumer.sol`](https://github.com/InfinityVM/InfinityVM/blob/main/contracts/src/examples/clob/ClobConsumer.sol).
+The CLOB app contract is [`ClobConsumer.sol`](https://github.com/InfinityVM/InfinityVM/blob/main/contracts/src/clob/ClobConsumer.sol).
 
-All code for the CLOB server lives in [`clob/`](https://github.com/InfinityVM/InfinityVM/tree/main/clob) in the InfinityVM repo. Specifically:
+All code for the CLOB server lives in [`examples/clob/`](https://github.com/InfinityVM/InfinityVM/tree/main/examples/clob) in the InfinityVM repo. Specifically:
 
 - [node](https://github.com/InfinityVM/InfinityVM/tree/main/examples/clob/node): the CLOB service.
 - [client](https://github.com/InfinityVM/InfinityVM/tree/main/examples/clob/client): client for seeding accounts, depositing, placing orders, withdrawing, and viewing state.
 - [core](https://github.com/InfinityVM/InfinityVM/tree/main/examples/clob/core): Types and functions with the CLOB matching logic which is shared by the app server and zkVM program.
 
-The zkVM program for the CLOB is [`clob.rs`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/programs/app/src/clob.rs).
+The zkVM program for the CLOB is [`program/src/main.rs`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/programs/program/src/main.rs).
 
 #### Note: Code organization
 
 We defined a lot of the CLOB logic in a shared `core` crate so the code can be easily reused in both the app server and the zkVM program.
 
-For example, the CLOB engine has a [`tick` function](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/core/src/lib.rs#L282) in the `core` crate which processes a single request. This is used in the [app server code](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/node/src/engine.rs) to process each request sent to the server. This same code is reused in the zkVM program's [state transition function](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/core/src/lib.rs#L275), to process each request in the batch given as input.
+For example, the CLOB engine has a [`tick` function](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/core/src/lib.rs) in the `core` crate which processes a single request. This is used in the [app server code](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/node/src/engine.rs) to process each request sent to the server. This same code is reused in the zkVM program's [state transition function](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/core/src/lib.rs), to process each request in the batch given as input.
 
 This also allows the `tick` function to be easily unit tested without the restrictions of the zkVM.
 
@@ -95,7 +95,7 @@ The zkVM program takes in `onchain_input` and `offchain_input` as inputs. It doe
 
 1. Decodes `onchain_input` and `offchain_input`.
 2. Verifies the merkle proof against the state root provided in `onchain_input`.
-1. Runs the CLOB app's state transition function, which matches orders given the inputs from the batch in `offchain_input` and the existing order book + balances in the CLOB's state. We won't explain this function in detail here, but the code for this is in [`zkvm_stf`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/core/src/lib.rs#L275).
+1. Runs the CLOB app's state transition function, which matches orders given the inputs from the batch in `offchain_input` and the existing order book + balances in the CLOB's state. We won't explain this function in detail here, but the code for this is in [`zkvm_stf`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/clob/core/src/lib.rs).
 1. Returns an ABI-encoded output, which includes the new CLOB state root and a list of balance updates which will be processed by the CLOB app contract.
 
 The list of state updates sent to the CLOB contract is structured like this:

--- a/book/src/apps/matching-game.md
+++ b/book/src/apps/matching-game.md
@@ -33,9 +33,9 @@ By running the matching logic in the InfinityVM coprocessor, the game is able to
 
 ## Code Overview
 
-The matching game contract is [`MatchingGameConsumer.sol`](https://github.com/InfinityVM/InfinityVM/blob/main/contracts/src/examples/matching-game/MatchingGameConsumer.sol).
+The matching game contract is [`MatchingGameConsumer.sol`](https://github.com/InfinityVM/InfinityVM/blob/main/contracts/src/matching-game/MatchingGameConsumer.sol).
 
-All code for the matching game server lives in [`matching-game/`](https://github.com/InfinityVM/InfinityVM/tree/main/matching-game) in the InfinityVM repo. Specifically:
+All code for the matching game server lives in [`examples/matching-game/`](https://github.com/InfinityVM/InfinityVM/tree/main/examples/matching-game) in the InfinityVM repo. Specifically:
 
 - [server](https://github.com/InfinityVM/InfinityVM/tree/main/examples/matching-game/server):
     - [app.rs](https://github.com/InfinityVM/InfinityVM/tree/main/examples/matching-game/server/src/app.rs): Code for the matching game REST server
@@ -45,11 +45,11 @@ All code for the matching game server lives in [`matching-game/`](https://github
     - [batcher.rs](https://github.com/InfinityVM/InfinityVM/tree/main/examples/matching-game/server/src/batcher.rs): Background service which batches requests and sends them to the InfinityVM coprocessor for matching
 - [core](https://github.com/InfinityVM/InfinityVM/tree/main/examples/matching-game/core): Common types and functions with matching logic that are used in both the game server and zkVM program.
 
-The zkVM program for the matching game is [`matching_game.rs`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/matching-game/programs/app/src/matching_game.rs).
+The zkVM program for the matching game is [`program/src/main.rs`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/matching-game/programs/program/src/main.rs).
 
 #### Note: Code organization
 
-We defined a lot of the matching logic (such as the `apply_requests` function) in a shared `core` crate so the code can be easily reused in both the game server and the zkVM program. 
+We defined a lot of the matching logic (such as the `apply_requests` function) in a shared `core` crate so the code can be easily reused in both the game server and the zkVM program.
 
 This also allows the `apply_requests` function to be easily unit tested without the restrictions of the zkVM.
 
@@ -98,11 +98,11 @@ In the matching game example, we use the [`kairos-tree`](https://github.com/cspr
 
 ## zkVM program
 
-The zkVM program ([`matching_game.rs`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/matching-game/programs/app/src/matching_game.rs)) takes in `onchain_input` and `offchain_input` as inputs. It does these things:
+The zkVM program ([`program/src/main.rs`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/matching-game/programs/program/src/main.rs)) takes in `onchain_input` and `offchain_input` as inputs. It does these things:
 
 1. Decodes `onchain_input` and `offchain_input`.
 1. Verifies merkle proof against the state root provided in `onchain_input`.
-1. Runs the matching game's state transition function, which matches players given the inputs from the batch in `offchain_input` and the list of pending requests in the game's state. We won't explain this function in detail here, but the code for this is in [`apply_requests`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/matching-game/core/src/lib.rs#L75).
+1. Runs the matching game's state transition function, which matches players given the inputs from the batch in `offchain_input` and the list of pending requests in the game's state. We won't explain this function in detail here, but the code for this is in [`apply_requests`](https://github.com/InfinityVM/InfinityVM/blob/main/examples/matching-game/core/src/lib.rs).
 1. Returns an ABI-encoded output, which includes the new game state root and a list of matched players which will be processed by the game contract to update the contract's state.
 
 ## Ensuring correctness of the state root

--- a/book/src/coprocessor/api.md
+++ b/book/src/coprocessor/api.md
@@ -1,6 +1,6 @@
 # Coprocessor Node API
 
-The coprocessor node exposes [gRPC](https://grpc.io/about/) endpoints for third party interaction. gRPC is a modern standard used widely in the web2 world. gRPC services are defined in [protobuf](https://protobuf.dev/overview/) and most major languages have production grade tooling to generate clients and servers based off of the protobuf definitions. All of the protobuf definitions can be found [here](https://github.com/InfinityVM/InfinityVM/blob/main/proto/coprocessor_node/v1/coprocessor_node.proto#L9).
+The coprocessor node exposes [gRPC](https://grpc.io/about/) endpoints for third party interaction. gRPC is a modern standard used widely in the web2 world. gRPC services are defined in [protobuf](https://protobuf.dev/overview/) and most major languages have production grade tooling to generate clients and servers based off of the protobuf definitions. All of the protobuf definitions can be found [here](https://github.com/InfinityVM/InfinityVM/blob/main/proto/coprocessor_node/v1/coprocessor_node.proto).
 
 Additionally, there is an embedded [json HTTP gateway](https://github.com/InfinityVM/InfinityVM/blob/main/crates/coprocessor-node/src/gateway.rs) with endpoints mapping 1:1 with each gRPC endpoint. This is useful when using tooling, (e.g. load testing frameworks), that does not support gRPC out of the box.
 
@@ -8,7 +8,7 @@ To learn more about how to use the gRPC API to build an application, take a look
 
 ## Clients
 
-The InfinityVM team ships a Rust gRPC client, which can be found in the [`proto` crate](https://github.com/InfinityVM/InfinityVM/blob/main/crates/sdk/proto/src/coprocessor_node.v1.rs#L236). As mentioned above, gRPC clients can be generated in other languages based off of the protobuf definitions.
+The InfinityVM team ships a Rust gRPC client, which can be found in the [`proto` crate](https://github.com/InfinityVM/InfinityVM/blob/main/crates/sdk/proto/src/coprocessor_node.v1.rs). As mentioned above, gRPC clients can be generated in other languages based off of the protobuf definitions.
 
 ## Endpoints
 

--- a/book/src/integration/offchain.md
+++ b/book/src/integration/offchain.md
@@ -47,7 +47,7 @@ A few notes:
 - `consumer`: address of your app contract.
 - `programId`: unique ID of your program. You can get the program ID when you submit your program to the coprocessor node's [`SubmitProgram` endpoint](../coprocessor/api.md#coprocessor_nodev1coprocessornodesubmitprogram).
 
-The `SubmitJob` endpoint returns a **unique Job ID** for the job. The job ID [can be derived](https://github.com/InfinityVM/InfinityVM/blob/main/crates/sdk/abi/src/lib.rs#L65) from the `nonce` and `consumer` address.
+The `SubmitJob` endpoint returns a **unique Job ID** for the job. The job ID [can be derived](https://github.com/InfinityVM/InfinityVM/blob/main/crates/sdk/abi/src/lib.rs) from the `nonce` and `consumer` address.
 
 ### GetResult
 
@@ -114,7 +114,7 @@ Similar to onchain jobs, any app contract building with InfinityVM needs to inhe
 
 For apps that use offchain jobs, you can also inherit [`OffchainRequester`](https://github.com/InfinityVM/InfinityVM/blob/main/contracts/src/coprocessor/OffchainRequester.sol), which contains the `isValidSignature()` function. You need to implement `isValidSignature()` in your app contract, which is called to verify that an offchain request is signed by an authorized signer/user. 
 
-We've provided an example implementation of [`isValidSignature()`](https://github.com/InfinityVM/InfinityVM/blob/main/contracts/src/coprocessor/SingleOffchainSigner.sol#L21) which you can use in the [`SingleOffchainSigner.sol` contract](https://github.com/InfinityVM/InfinityVM/blob/zeke-reorg-docs/contracts/src/coprocessor/SingleOffchainSigner.sol) (this checks that each job request is signed by a single pre-defined `offchainSigner` address). But, you can implement any logic or checks you'd like. For example, you could store a list of whitelisted users in your app contract and add logic in `isValidSignature()` to verify that every job request is signed by some whitelisted user.
+We've provided an example implementation of [`isValidSignature()`](https://github.com/InfinityVM/InfinityVM/blob/main/contracts/src/coprocessor/SingleOffchainSigner.sol) which you can use in the [`SingleOffchainSigner.sol` contract](https://github.com/InfinityVM/InfinityVM/blob/zeke-reorg-docs/contracts/src/coprocessor/SingleOffchainSigner.sol) (this checks that each job request is signed by a single pre-defined `offchainSigner` address). But, you can implement any logic or checks you'd like. For example, you could store a list of whitelisted users in your app contract and add logic in `isValidSignature()` to verify that every job request is signed by some whitelisted user.
 
 Finally, you need to write a `_receiveResult()` callback function which accepts the output from the InfinityVM coprocessor running your program. You can write any app logic in this function and even call into any other functions you'd like.
 
@@ -128,7 +128,7 @@ We have provided a default implementation for `getNextNonce()` and `updateLatest
 
 If you just want to test sending offchain job requests directly to the InfinityVM coprocessor without an app server, you can use the [`InfinityVM foundry template`](https://github.com/InfinityVM/infinityVM-foundry-template/tree/main) to test your app. You can write tests for the end-to-end flow of your app in Solidity similar to any other foundry tests. We have built a Solidity SDK within the foundry template which allows you to request and receive compute from InfinityVM within the foundry tests.
 
-Specifically, you just need to call `requestOffchainJob()` in the foundry tests to send an offchain job request to the coprocessor. We have written an example test [`test_Consumer_RequestOffchainJob()`](https://github.com/InfinityVM/infinityVM-foundry-template/blob/main/contracts/test/SquareRootConsumer.t.sol#L41) in [`SquareRootConsumer.t.sol`](https://github.com/InfinityVM/infinityVM-foundry-template/blob/main/contracts/test/SquareRootConsumer.t.sol). This test sends an offchain request for the square root of a number directly to the coprocessor, using `requestOffchainJob()`. It verifies that the coprocessor submits the correct result back to the `SquareRootConsumer.sol` contract.
+Specifically, you just need to call `requestOffchainJob()` in the foundry tests to send an offchain job request to the coprocessor. We have written an example test [`test_Consumer_RequestOffchainJob()`](https://github.com/InfinityVM/infinityVM-foundry-template/blob/main/contracts/test/SquareRootConsumer.t.sol) in [`SquareRootConsumer.t.sol`](https://github.com/InfinityVM/infinityVM-foundry-template/blob/main/contracts/test/SquareRootConsumer.t.sol). This test sends an offchain request for the square root of a number directly to the coprocessor, using `requestOffchainJob()`. It verifies that the coprocessor submits the correct result back to the `SquareRootConsumer.sol` contract.
 
 #### Testing an App Server
 

--- a/book/src/integration/onchain.md
+++ b/book/src/integration/onchain.md
@@ -21,4 +21,4 @@ Typically, we expect an onchain request to be triggered by user interaction with
 
 In the foundry template, you can write tests for the end-to-end flow of your app in Solidity similar to any other foundry tests. We have built a Solidity SDK within the foundry template which allows you to request and receive compute from InfinityVM within the foundry tests.
 
-One example of this is [`test_Consumer_RequestJob`](https://github.com/InfinityVM/infinityVM-foundry-template/blob/main/contracts/test/SquareRootConsumer.t.sol#L26). You can run the test using `forge test -vvv --ffi`.
+One example of this is [`test_Consumer_RequestJob`](https://github.com/InfinityVM/infinityVM-foundry-template/blob/main/contracts/test/SquareRootConsumer.t.sol). You can run the test using `forge test -vvv --ffi`.

--- a/book/src/integration/writing-program.md
+++ b/book/src/integration/writing-program.md
@@ -84,7 +84,7 @@ fn main() {
 
 Assuming you organize the main function of your zkVM program as above, you can have all your logic in a single pure function. If your logic is more complex, you can also write your code in a separate crate such that the code can be easily reused and unit tested without the restrictions of the zkVM.
 
-**Note:** Any of the dependencies you use in your zkVM program need to be compatible with the zkVM; roughly 70% of major crates are compatible. A common issue is the [alloy](https://docs.rs/crate/alloy/latest/features) crate, which works with most of the [features disabled](https://github.com/InfinityVM/InfinityVM/blob/main/Cargo.toml#L118), but breaks builds with the [`full` feature](https://github.com/alloy-rs/alloy/blob/main/crates/alloy/Cargo.toml#L76) enabled. Don't hesitate to reach out to the InfinityVM team if you face any challenges with this!
+**Note:** Any of the dependencies you use in your zkVM program need to be compatible with the zkVM; roughly 70% of major crates are compatible. A common issue is the [alloy](https://docs.rs/crate/alloy/latest/features) crate, which works with most of the [features disabled](https://github.com/InfinityVM/InfinityVM/blob/main/Cargo.toml), but breaks builds with the [`full` feature](https://github.com/alloy-rs/alloy/blob/main/crates/alloy/Cargo.toml) enabled. Don't hesitate to reach out to the InfinityVM team if you face any challenges with this!
 
 ## Testing your program
 


### PR DESCRIPTION
# What

- Updates some of the info in the book to sp1 (repo structure, zkVM program code, etc.)
- Removes line numbers in any github URLs in the book because these line numbers keep changing and we don't want to confuse readers by directing them to wrong line numbers
