### PR TITLE
fix: add cargo rerun for ELF builds

### DIFF
--- a/examples/clob/programs/build.rs
+++ b/examples/clob/programs/build.rs
@@ -1,5 +1,12 @@
 use ivm_sp1_utils::build_sp1_program;
 
 fn main() {
+    let current_dir = std::env::current_dir().unwrap();
+    println!("cargo:rerun-if-changed={}", current_dir.join("src/lib.rs").display());
+    println!("cargo:rerun-if-changed={}", current_dir.join("Cargo.toml").display());
+
+    println!("cargo:rerun-if-changed={}", current_dir.join("program/src/main.rs").display());
+    println!("cargo:rerun-if-changed={}", current_dir.join("program/Cargo.toml").display());
+
     build_sp1_program("clob-sp1-guest", "program/", "target/sp1/clob/");
 }

--- a/examples/matching-game/programs/build.rs
+++ b/examples/matching-game/programs/build.rs
@@ -1,5 +1,12 @@
 use ivm_sp1_utils::build_sp1_program;
 
 fn main() {
+    let current_dir = std::env::current_dir().unwrap();
+    println!("cargo:rerun-if-changed={}", current_dir.join("src/lib.rs").display());
+    println!("cargo:rerun-if-changed={}", current_dir.join("Cargo.toml").display());
+
+    println!("cargo:rerun-if-changed={}", current_dir.join("program/src/main.rs").display());
+    println!("cargo:rerun-if-changed={}", current_dir.join("program/Cargo.toml").display());
+
     build_sp1_program("matching-game-sp1-guest", "program/", "target/sp1/matching-game/");
 }

--- a/programs/intensity-test/build.rs
+++ b/programs/intensity-test/build.rs
@@ -1,5 +1,12 @@
 use ivm_sp1_utils::build_sp1_program;
 
 fn main() {
+    let current_dir = std::env::current_dir().unwrap();
+    println!("cargo:rerun-if-changed={}", current_dir.join("src/lib.rs").display());
+    println!("cargo:rerun-if-changed={}", current_dir.join("Cargo.toml").display());
+
+    println!("cargo:rerun-if-changed={}", current_dir.join("program/src/main.rs").display());
+    println!("cargo:rerun-if-changed={}", current_dir.join("program/Cargo.toml").display());
+
     build_sp1_program("intensity-test-sp1-guest", "program/", "target/sp1/intensity-test/");
 }

--- a/programs/mock-consumer/build.rs
+++ b/programs/mock-consumer/build.rs
@@ -1,5 +1,11 @@
 use ivm_sp1_utils::build_sp1_program;
 
 fn main() {
+    let current_dir = std::env::current_dir().unwrap();
+    println!("cargo:rerun-if-changed={}", current_dir.join("src/lib.rs").display());
+    println!("cargo:rerun-if-changed={}", current_dir.join("Cargo.toml").display());
+
+    println!("cargo:rerun-if-changed={}", current_dir.join("program/src/main.rs").display());
+    println!("cargo:rerun-if-changed={}", current_dir.join("program/Cargo.toml").display());
     build_sp1_program("mock-consumer-sp1-guest", "program/", "target/sp1/mock-consumer/");
 }


### PR DESCRIPTION
# What

- Add `cargo rerun` to the `build.rs` scripts for ELFs so we don't need to rebuild the ELFs every time we run `cargo build`

# Testing

Ran `cargo build` a few times and verified that we don't rebuild the ELFs
