### PR TITLE
refactor: use program ID path instead of lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,6 @@ dependencies = [
  "ivm-abi",
  "ivm-sp1-utils",
  "ivm-zkvm",
- "once_cell",
  "sp1-build 3.3.0",
  "sp1-sdk",
 ]
@@ -3409,7 +3408,6 @@ name = "intensity-test-programs"
 version = "0.1.0"
 dependencies = [
  "ivm-sp1-utils",
- "once_cell",
  "sp1-build 3.3.0",
  "sp1-sdk",
 ]
@@ -3845,7 +3843,6 @@ dependencies = [
  "ivm-zkvm",
  "kairos-trie",
  "matching-game-core",
- "once_cell",
  "sp1-build 3.3.0",
  "sp1-sdk",
 ]
@@ -3975,7 +3972,6 @@ name = "mock-consumer-programs"
 version = "0.1.0"
 dependencies = [
  "ivm-sp1-utils",
- "once_cell",
  "sp1-build 3.3.0",
  "sp1-sdk",
 ]

--- a/crates/scripts/src/local.rs
+++ b/crates/scripts/src/local.rs
@@ -5,14 +5,14 @@ use clob_node::{
     CLOB_BATCHER_DURATION_MS, CLOB_CN_GRPC_ADDR, CLOB_CONSUMER_ADDR, CLOB_DB_DIR, CLOB_ETH_WS_ADDR,
     CLOB_JOB_SYNC_START, CLOB_LISTEN_ADDR, CLOB_OPERATOR_KEY,
 };
-use clob_programs::{get_clob_program_id, CLOB_ELF};
+use clob_programs::{CLOB_ELF, CLOB_PROGRAM_ID};
 use clob_test_utils::{anvil_with_clob_consumer, mint_and_approve};
 use contracts::{DeployInfo, DEFAULT_DEPLOY_INFO};
-use intensity_test_programs::{get_intensity_test_program_id, INTENSITY_TEST_ELF};
+use intensity_test_programs::{INTENSITY_TEST_ELF, INTENSITY_TEST_PROGRAM_ID};
 use ivm_proto::{coprocessor_node_client::CoprocessorNodeClient, SubmitProgramRequest, VmType};
 use ivm_test_utils::{anvil_with_job_manager, sleep_until_bound_config, ProcKill, LOCALHOST};
 use mock_consumer::anvil_with_mock_consumer;
-use mock_consumer_programs::{get_mock_consumer_program_id, MOCK_CONSUMER_ELF};
+use mock_consumer_programs::{MOCK_CONSUMER_ELF, MOCK_CONSUMER_PROGRAM_ID};
 use std::{fs::File, process::Command};
 use tokio::signal::unix::{signal, SignalKind};
 use tracing::{info, warn};
@@ -135,7 +135,7 @@ async fn main() {
         let submit_program_request = SubmitProgramRequest {
             program_elf: CLOB_ELF.to_vec(),
             vm_type: VmType::Sp1.into(),
-            program_id: get_clob_program_id().to_vec(),
+            program_id: CLOB_PROGRAM_ID.to_vec(),
         };
         coproc_client.submit_program(submit_program_request).await.unwrap();
 
@@ -143,7 +143,7 @@ async fn main() {
         let submit_program_request = SubmitProgramRequest {
             program_elf: MOCK_CONSUMER_ELF.to_vec(),
             vm_type: VmType::Sp1.into(),
-            program_id: get_mock_consumer_program_id().to_vec(),
+            program_id: MOCK_CONSUMER_PROGRAM_ID.to_vec(),
         };
         coproc_client.submit_program(submit_program_request).await.unwrap();
 
@@ -151,7 +151,7 @@ async fn main() {
         let submit_program_request = SubmitProgramRequest {
             program_elf: INTENSITY_TEST_ELF.to_vec(),
             vm_type: VmType::Sp1.into(),
-            program_id: get_intensity_test_program_id().to_vec(),
+            program_id: INTENSITY_TEST_PROGRAM_ID.to_vec(),
         };
         coproc_client.submit_program(submit_program_request).await.unwrap();
     }

--- a/crates/scripts/src/node_test.rs
+++ b/crates/scripts/src/node_test.rs
@@ -7,7 +7,7 @@ use alloy::{
     signers::local::LocalSigner,
     sol_types::SolValue,
 };
-use clob_programs::{get_clob_program_id, CLOB_ELF};
+use clob_programs::{CLOB_ELF, CLOB_PROGRAM_ID};
 use contracts::mock_consumer::MockConsumer;
 use ivm_abi::StatefulAppOnchainInput;
 use ivm_proto::{
@@ -21,10 +21,10 @@ use matching_game_core::{
     api::{Request, SubmitNumberRequest},
     get_merkle_root_bytes, next_state,
 };
-use matching_game_programs::{get_matching_game_program_id, MATCHING_GAME_ELF};
+use matching_game_programs::{MATCHING_GAME_ELF, MATCHING_GAME_PROGRAM_ID};
 use matching_game_server::contracts::matching_game_consumer::MatchingGameConsumer;
 use mock_consumer::MOCK_CONSUMER_MAX_CYCLES;
-use mock_consumer_programs::{get_mock_consumer_program_id, MOCK_CONSUMER_ELF};
+use mock_consumer_programs::{MOCK_CONSUMER_ELF, MOCK_CONSUMER_PROGRAM_ID};
 use std::rc::Rc;
 use tracing::{error, info};
 
@@ -53,7 +53,7 @@ async fn main() {
     let submit_program_request = SubmitProgramRequest {
         program_elf: CLOB_ELF.to_vec(),
         vm_type: VmType::Sp1.into(),
-        program_id: get_clob_program_id().to_vec(),
+        program_id: CLOB_PROGRAM_ID.to_vec(),
     };
     // We handle error here because we don't want to panic if the ELF was already submitted
     match coproc_client.submit_program(submit_program_request).await {
@@ -69,7 +69,7 @@ async fn main() {
     let submit_program_request = SubmitProgramRequest {
         program_elf: MOCK_CONSUMER_ELF.to_vec(),
         vm_type: VmType::Sp1.into(),
-        program_id: get_mock_consumer_program_id().to_vec(),
+        program_id: MOCK_CONSUMER_PROGRAM_ID.to_vec(),
     };
     // We handle error here because we don't want to panic if the ELF was already submitted
     match coproc_client.submit_program(submit_program_request).await {
@@ -85,7 +85,7 @@ async fn main() {
     let submit_program_request = SubmitProgramRequest {
         program_elf: MATCHING_GAME_ELF.to_vec(),
         vm_type: VmType::Sp1.into(),
-        program_id: get_matching_game_program_id().to_vec(),
+        program_id: MATCHING_GAME_PROGRAM_ID.to_vec(),
     };
     // We handle error here because we don't want to panic if the ELF was already submitted
     match coproc_client.submit_program(submit_program_request).await {
@@ -119,7 +119,7 @@ async fn main() {
         MOCK_CONSUMER_MAX_CYCLES,
         mock_consumer_addr,
         Address::abi_encode(&mock_consumer_addr).as_slice(),
-        &get_mock_consumer_program_id()[..],
+        &MOCK_CONSUMER_PROGRAM_ID,
         offchain_signer.clone(),
         &[],
     )
@@ -217,14 +217,12 @@ async fn main() {
     };
     let onchain_input_abi_encoded = StatefulAppOnchainInput::abi_encode(&onchain_input);
 
-    let matching_game_program_id = get_matching_game_program_id();
-
     let (encoded_job_request, signature) = create_and_sign_offchain_request(
         nonce,
         MOCK_CONSUMER_MAX_CYCLES,
         matching_game_consumer_addr,
         onchain_input_abi_encoded.as_slice(),
-        &matching_game_program_id,
+        &MATCHING_GAME_PROGRAM_ID,
         offchain_signer.clone(),
         &combined_offchain_input,
     )

--- a/crates/sdk/sp1-utils/src/lib.rs
+++ b/crates/sdk/sp1-utils/src/lib.rs
@@ -29,13 +29,3 @@ pub fn build_sp1_program(elf_name: &str, program_dir: &str, output_dir: &str) {
         fs::write(&program_id_path_abs, program_id).expect("Failed to write program ID file");
     }
 }
-
-pub fn get_program_id(program_id_path: &str) -> [u8; 32] {
-    // We need to get the workspace root to convert the program ID path to an absolute path
-    let metadata = MetadataCommand::new().no_deps().exec().unwrap();
-    let workspace_root = metadata.workspace_root;
-
-    let program_id_path_abs = PathBuf::from(workspace_root).join(program_id_path);
-    let program_id = fs::read(program_id_path_abs).expect("Failed to read program ID file");
-    program_id.try_into().expect("Invalid program ID length")
-}

--- a/crates/zkvm/src/lib.rs
+++ b/crates/zkvm/src/lib.rs
@@ -100,7 +100,7 @@ mod test {
 
     #[test]
     fn sp1_is_correct_program_id() {
-        let program_id_bytes = mock_consumer_programs::get_mock_consumer_program_id().to_vec();
+        let program_id_bytes = mock_consumer_programs::MOCK_CONSUMER_PROGRAM_ID.to_vec();
 
         let correct = &Sp1.is_correct_program_id(MOCK_CONSUMER_ELF, &program_id_bytes).unwrap();
         assert!(correct);

--- a/examples/clob/node/src/batcher.rs
+++ b/examples/clob/node/src/batcher.rs
@@ -8,7 +8,7 @@ use crate::{
     K256LocalSigner,
 };
 use alloy::{primitives::utils::keccak256, signers::Signer, sol_types::SolValue};
-use clob_programs::get_clob_program_id;
+use clob_programs::CLOB_PROGRAM_ID;
 use eyre::OptionExt;
 use ivm_abi::{abi_encode_offchain_job_request, JobParams, StatefulAppOnchainInput};
 use ivm_proto::{coprocessor_node_client::CoprocessorNodeClient, RelayStrategy, SubmitJobRequest};
@@ -64,7 +64,7 @@ where
 {
     // Wait for the system to have at least one processed request from the CLOB server
     ensure_initialized(Arc::clone(&db)).await?;
-    let program_id = get_clob_program_id();
+    let program_id = CLOB_PROGRAM_ID;
 
     let mut coprocessor_node = CoprocessorNodeClient::connect(cn_grpc_url).await.unwrap();
     let mut interval = tokio::time::interval(sleep_duration);

--- a/examples/clob/programs/Cargo.toml
+++ b/examples/clob/programs/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-ivm-sp1-utils = { workspace = true }
-once_cell = { workspace = true }
 
 [dev-dependencies]
 clob-core = { workspace = true }

--- a/examples/clob/programs/src/lib.rs
+++ b/examples/clob/programs/src/lib.rs
@@ -1,16 +1,7 @@
-use ivm_sp1_utils::get_program_id;
-use once_cell::sync::Lazy;
-
 pub const CLOB_ELF: &[u8] = include_bytes!("../../../../target/sp1/clob/clob-sp1-guest");
 
-static CLOB_PROGRAM_ID: Lazy<[u8; 32]> = Lazy::new(|| {
-    let program_id_path = "target/sp1/clob/clob-sp1-guest.vkey";
-    get_program_id(program_id_path)
-});
-
-pub fn get_clob_program_id() -> [u8; 32] {
-    *CLOB_PROGRAM_ID
-}
+pub const CLOB_PROGRAM_ID: [u8; 32] =
+    *include_bytes!("../../../../target/sp1/clob/clob-sp1-guest.vkey");
 
 #[cfg(test)]
 mod tests {

--- a/examples/matching-game/programs/Cargo.toml
+++ b/examples/matching-game/programs/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-once_cell = { workspace = true }
-ivm-sp1-utils = { workspace = true }
 ivm-zkvm = { workspace = true }
 
 [dev-dependencies]

--- a/examples/matching-game/programs/src/lib.rs
+++ b/examples/matching-game/programs/src/lib.rs
@@ -1,17 +1,8 @@
-use ivm_sp1_utils::get_program_id;
-use once_cell::sync::Lazy;
-
 pub const MATCHING_GAME_ELF: &[u8] =
     include_bytes!("../../../../target/sp1/matching-game/matching-game-sp1-guest");
 
-static MATCHING_GAME_PROGRAM_ID: Lazy<[u8; 32]> = Lazy::new(|| {
-    let program_id_path = "target/sp1/matching-game/matching-game-sp1-guest.vkey";
-    get_program_id(program_id_path)
-});
-
-pub fn get_matching_game_program_id() -> [u8; 32] {
-    *MATCHING_GAME_PROGRAM_ID
-}
+pub const MATCHING_GAME_PROGRAM_ID: [u8; 32] =
+    *include_bytes!("../../../../target/sp1/matching-game/matching-game-sp1-guest.vkey");
 
 #[cfg(test)]
 mod tests {

--- a/examples/matching-game/server/src/batcher.rs
+++ b/examples/matching-game/server/src/batcher.rs
@@ -7,7 +7,7 @@ use ivm_abi::{abi_encode_offchain_job_request, JobParams, StatefulAppOnchainInpu
 use ivm_proto::{coprocessor_node_client::CoprocessorNodeClient, RelayStrategy, SubmitJobRequest};
 use kairos_trie::{stored::memory_db::MemoryDb, TrieRoot};
 use matching_game_core::{get_merkle_root_bytes, next_state};
-use matching_game_programs::get_matching_game_program_id;
+use matching_game_programs::MATCHING_GAME_PROGRAM_ID;
 use std::{rc::Rc, sync::Arc};
 use tokio::time::{sleep, Duration};
 use tonic::transport::Channel;
@@ -44,7 +44,7 @@ pub async fn run_batcher(
 ) -> eyre::Result<()> {
     // Wait for the system to have at least one processed request from the matching game server
     ensure_initialized(Arc::clone(&state)).await?;
-    let program_id = get_matching_game_program_id();
+    let program_id = MATCHING_GAME_PROGRAM_ID;
 
     let mut coprocessor_node = CoprocessorNodeClient::connect(cn_grpc_url).await.unwrap();
     let mut interval = tokio::time::interval(sleep_duration);

--- a/programs/intensity-test/Cargo.toml
+++ b/programs/intensity-test/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-once_cell = { workspace = true, features = ["std"] }
-ivm-sp1-utils = { workspace = true }
 
 [build-dependencies]
 sp1-build = { workspace = true }

--- a/programs/intensity-test/src/lib.rs
+++ b/programs/intensity-test/src/lib.rs
@@ -1,14 +1,5 @@
-use ivm_sp1_utils::get_program_id;
-use once_cell::sync::Lazy;
-
 pub const INTENSITY_TEST_ELF: &[u8] =
     include_bytes!("../../../target/sp1/intensity-test/intensity-test-sp1-guest");
 
-static INTENSITY_TEST_PROGRAM_ID: Lazy<[u8; 32]> = Lazy::new(|| {
-    let program_id_path = "target/sp1/intensity-test/intensity-test-sp1-guest.vkey";
-    get_program_id(program_id_path)
-});
-
-pub fn get_intensity_test_program_id() -> [u8; 32] {
-    *INTENSITY_TEST_PROGRAM_ID
-}
+pub const INTENSITY_TEST_PROGRAM_ID: [u8; 32] =
+    *include_bytes!("../../../target/sp1/intensity-test/intensity-test-sp1-guest.vkey");

--- a/programs/mock-consumer/Cargo.toml
+++ b/programs/mock-consumer/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-once_cell = { workspace = true, features = ["std"] }
-ivm-sp1-utils = { workspace = true }
 
 [build-dependencies]
 sp1-build = { workspace = true }

--- a/programs/mock-consumer/src/lib.rs
+++ b/programs/mock-consumer/src/lib.rs
@@ -1,14 +1,5 @@
-use ivm_sp1_utils::get_program_id;
-use once_cell::sync::Lazy;
-
 pub const MOCK_CONSUMER_ELF: &[u8] =
     include_bytes!("../../../target/sp1/mock-consumer/mock-consumer-sp1-guest");
 
-static MOCK_CONSUMER_PROGRAM_ID: Lazy<[u8; 32]> = Lazy::new(|| {
-    let program_id_path = "target/sp1/mock-consumer/mock-consumer-sp1-guest.vkey";
-    get_program_id(program_id_path)
-});
-
-pub fn get_mock_consumer_program_id() -> [u8; 32] {
-    *MOCK_CONSUMER_PROGRAM_ID
-}
+pub const MOCK_CONSUMER_PROGRAM_ID: [u8; 32] =
+    *include_bytes!("../../../target/sp1/mock-consumer/mock-consumer-sp1-guest.vkey");

--- a/test/e2e/tests/clob.rs
+++ b/test/e2e/tests/clob.rs
@@ -13,7 +13,7 @@ use clob_core::{
     },
     BorshKeccak256, ClobState,
 };
-use clob_programs::{get_clob_program_id, CLOB_ELF};
+use clob_programs::{CLOB_ELF, CLOB_PROGRAM_ID};
 use clob_test_utils::{mint_and_approve, mock_erc20::MockErc20, next_state};
 use e2e::{Args, E2E};
 use ivm_abi::{
@@ -29,7 +29,7 @@ async fn state_job_submission_clob_consumer() {
     async fn test(mut args: Args) {
         let anvil = args.anvil;
         let clob = args.clob_consumer.unwrap();
-        let program_id = get_clob_program_id();
+        let program_id = CLOB_PROGRAM_ID;
         let clob_signer_wallet = EthereumWallet::from(clob.clob_signer.clone());
         let clob_state0 = ClobState::default();
 
@@ -231,7 +231,7 @@ async fn clob_node_e2e() {
     async fn test(mut args: Args) {
         let anvil = args.anvil;
         let clob = args.clob_consumer.unwrap();
-        let program_id = get_clob_program_id();
+        let program_id = CLOB_PROGRAM_ID;
         let clob_signer_wallet = EthereumWallet::from(clob.clob_signer.clone());
         let clob_endpoint = args.clob_endpoint.unwrap();
 

--- a/test/e2e/tests/matching_game.rs
+++ b/test/e2e/tests/matching_game.rs
@@ -19,7 +19,7 @@ use matching_game_core::{
     },
     get_merkle_root_bytes, next_state,
 };
-use matching_game_programs::{get_matching_game_program_id, MATCHING_GAME_ELF};
+use matching_game_programs::{MATCHING_GAME_ELF, MATCHING_GAME_PROGRAM_ID};
 use matching_game_server::contracts::matching_game_consumer::MatchingGameConsumer;
 use std::rc::Rc;
 use tokio::time::{sleep, Duration};
@@ -30,7 +30,7 @@ async fn state_job_submission_matching_game_consumer() {
     async fn test(mut args: Args) {
         let anvil = args.anvil;
         let matching_game = args.matching_game_consumer.unwrap();
-        let program_id = get_matching_game_program_id();
+        let program_id = MATCHING_GAME_PROGRAM_ID;
         let matching_game_signer_wallet =
             EthereumWallet::from(matching_game.matching_game_signer.clone());
 
@@ -175,7 +175,7 @@ async fn matching_game_server_e2e() {
     async fn test(mut args: Args) {
         let anvil = args.anvil;
         let matching_game = args.matching_game_consumer.unwrap();
-        let program_id = get_matching_game_program_id();
+        let program_id = MATCHING_GAME_PROGRAM_ID;
         let matching_game_signer_wallet =
             EthereumWallet::from(matching_game.matching_game_signer.clone());
         let matching_game_endpoint = args.matching_game_endpoint.unwrap();

--- a/test/e2e/tests/mock_consumer.rs
+++ b/test/e2e/tests/mock_consumer.rs
@@ -20,7 +20,7 @@ use ivm_proto::{
     GetResultRequest, JobStatusType, RelayStrategy, SubmitJobRequest, SubmitProgramRequest, VmType,
 };
 use mock_consumer::MOCK_CONSUMER_MAX_CYCLES;
-use mock_consumer_programs::{get_mock_consumer_program_id, MOCK_CONSUMER_ELF};
+use mock_consumer_programs::{MOCK_CONSUMER_ELF, MOCK_CONSUMER_PROGRAM_ID};
 
 type MockConsumerOut = sol!((Address, U256));
 
@@ -30,7 +30,7 @@ async fn web2_job_submission_coprocessor_node_mock_consumer_e2e() {
     async fn test(mut args: Args) {
         let mock = args.mock_consumer.unwrap();
         let anvil = args.anvil;
-        let program_id = get_mock_consumer_program_id();
+        let program_id = MOCK_CONSUMER_PROGRAM_ID;
         let mock_user_address = Address::repeat_byte(69);
 
         let random_user: PrivateKeySigner = anvil.anvil.keys()[5].clone().into();
@@ -164,7 +164,7 @@ async fn event_job_created_coprocessor_node_mock_consumer_e2e() {
     async fn test(mut args: Args) {
         let mock = args.mock_consumer.unwrap();
         let anvil = args.anvil;
-        let program_id = get_mock_consumer_program_id();
+        let program_id = MOCK_CONSUMER_PROGRAM_ID;
         let mock_user_address = Address::repeat_byte(69);
 
         let random_user: PrivateKeySigner = anvil.anvil.keys()[5].clone().into();

--- a/test/load-test/src/main.rs
+++ b/test/load-test/src/main.rs
@@ -3,7 +3,7 @@ use alloy::{primitives::Address, providers::ProviderBuilder, sol_types::SolValue
 use borsh::{BorshDeserialize, BorshSerialize};
 use contracts::mock_consumer::MockConsumer;
 use goose::prelude::*;
-use intensity_test_programs::get_intensity_test_program_id;
+use intensity_test_programs::INTENSITY_TEST_PROGRAM_ID;
 use ivm_abi::get_job_id;
 use ivm_proto::{GetResultRequest, RelayStrategy, SubmitJobRequest};
 use load_test::{
@@ -12,7 +12,7 @@ use load_test::{
     report_file_name, run_time, should_wait_until_job_completed, startup_time,
     wait_until_job_completed,
 };
-use mock_consumer_programs::get_mock_consumer_program_id;
+use mock_consumer_programs::MOCK_CONSUMER_PROGRAM_ID;
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::OnceCell;
@@ -86,7 +86,7 @@ pub async fn submit_first_job() -> Result<(), Box<dyn std::error::Error>> {
     if nonce == 1 {
         let consumer_addr =
             Address::parse_checksummed(consumer_addr(), None).expect("Valid address");
-        let program_id = get_mock_consumer_program_id();
+        let program_id = MOCK_CONSUMER_PROGRAM_ID;
         let (encoded_job_request, signature) = get_offchain_request(
             nonce,
             &program_id,
@@ -129,7 +129,7 @@ async fn loadtest_submit_job(user: &mut GooseUser) -> TransactionResult {
     let intensity_input = IntensityInput { hash_rounds: intensity_hash_rounds() };
     let encoded_intensity = borsh::to_vec(&intensity_input).unwrap();
 
-    let program_id = get_intensity_test_program_id();
+    let program_id = INTENSITY_TEST_PROGRAM_ID;
     let (encoded_job_request, signature) =
         get_offchain_request(nonce, &program_id, &encoded_intensity).await;
 


### PR DESCRIPTION
# What

- Uses the program ID path instead of lazy init

# Testing

`make test-all`: Passes
