### PR TITLE
fix: Add alloy features to get local script working

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ brew install protobuf
 ```sh
 # install protobuf compilation tools
 apt-get update
-apt-get install install protobuf-compiler
+apt-get install protobuf-compiler
 ```
 
 SP1

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,7 @@ contracts:
 	cp contracts/out/IJobManager.sol/IJobManager.json crates/contracts/json
 	cp contracts/out/MockConsumer.sol/MockConsumer.json crates/contracts/json
 	cp contracts/out/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json crates/contracts/json
+
+.PHONY: run
+run:
+	cargo run --bin local

--- a/crates/coprocessor-node/Cargo.toml
+++ b/crates/coprocessor-node/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-alloy = { workspace = true, features = ["reqwest", "provider-ws"] }
+alloy = { workspace = true, features = ["reqwest", "provider-ws", "signer-local", "rpc-types"] }
 tonic = { workspace = true }
 tonic-reflection = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
# What

`cargo run --bin local` was not working because of some missing Alloy features.

- Adds these features

# Testing

`make run`: Works correctly
