### PR TITLE
coproc -> ivm-reth

### DIFF
--- a/.github/workflows/docker-exec.yml
+++ b/.github/workflows/docker-exec.yml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            us-docker.pkg.dev/infinityvm-core-artifacts/docker/coproc
+            us-docker.pkg.dev/infinityvm-core-artifacts/docker/ivm-reth
           tags: |
             type=semver,pattern={{version}}
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
@@ -64,7 +64,7 @@ jobs:
             type=ref,enable=true,priority=600,prefix=pr-,suffix=,event=pr
             type=ref,enable=true,priority=600,prefix=,suffix=,event=tag
 
-      - id: docker-push-coproc
+      - id: docker-push-ivm-reth
         name: Tag Docker image and push to Google Artifact Registry
         uses: docker/build-push-action@v6
         if: env.GIT_DIFF || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
# What

Fixes the docker build and push for ivm reth which was erroneously pushing to the coproc docker repo