### PR TITLE
chore(deps): update reth & alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,27 +120,27 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59febb24956a41c29bb5f450978fbe825bd6456b3f80586c8bd558dc882e7b6a"
+checksum = "4305e0397a7eb57f4840a048583b7ab904eabd250264568fc65a7e38a76c9e40"
 dependencies = [
- "alloy-consensus 0.8.3",
+ "alloy-consensus 0.9.1",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 0.8.3",
- "alloy-genesis 0.8.3",
- "alloy-network 0.8.3",
+ "alloy-eips 0.9.1",
+ "alloy-genesis 0.9.1",
+ "alloy-network 0.9.1",
  "alloy-node-bindings",
- "alloy-provider 0.8.3",
- "alloy-pubsub 0.8.3",
- "alloy-rpc-client 0.8.3",
- "alloy-rpc-types 0.8.3",
- "alloy-serde 0.8.3",
- "alloy-signer 0.8.3",
- "alloy-signer-local 0.8.3",
- "alloy-transport 0.8.3",
- "alloy-transport-http 0.8.3",
- "alloy-transport-ws 0.8.3",
+ "alloy-provider 0.9.1",
+ "alloy-pubsub 0.9.1",
+ "alloy-rpc-client 0.9.1",
+ "alloy-rpc-types 0.9.1",
+ "alloy-serde 0.9.1",
+ "alloy-signer 0.9.1",
+ "alloy-signer-local 0.9.1",
+ "alloy-transport 0.9.1",
+ "alloy-transport-http 0.9.1",
+ "alloy-transport-ws 0.9.1",
 ]
 
 [[package]]
@@ -194,14 +194,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88e1edea70787c33e11197d3f32ae380f3db19e6e061e539a5bcf8184a6b326"
+checksum = "d802a6d579d924a2926d181bce43231aaab4699a7c206197e88fbc6b9dda846f"
 dependencies = [
- "alloy-eips 0.8.3",
+ "alloy-eips 0.9.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.8.3",
+ "alloy-serde 0.9.1",
  "alloy-trie",
  "auto_impl",
  "c-kzg",
@@ -225,34 +225,34 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b1bb53f40c0273cd1975573cd457b39213e68584e36d1401d25fd0398a1d65"
+checksum = "24b1bcb3e4810bff7e2a62ac0d741c70a7b5560e57b76eb0f0d33e1070735c60"
 dependencies = [
- "alloy-consensus 0.8.3",
- "alloy-eips 0.8.3",
+ "alloy-consensus 0.9.1",
+ "alloy-eips 0.9.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.8.3",
+ "alloy-serde 0.9.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b668c78c4b1f12f474ede5a85e8ce550d0aa1ef7d49fd1d22855a43b960e725"
+checksum = "8e56bc4dc06ab205dc4106348c44b92e0d979148f8db751994c11caabf5ebbef"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network 0.8.3",
- "alloy-network-primitives 0.8.3",
+ "alloy-network 0.9.1",
+ "alloy-network-primitives 0.9.1",
  "alloy-primitives",
- "alloy-provider 0.8.3",
- "alloy-pubsub 0.8.3",
- "alloy-rpc-types-eth 0.8.3",
+ "alloy-provider 0.9.1",
+ "alloy-pubsub 0.9.1",
+ "alloy-rpc-types-eth 0.9.1",
  "alloy-sol-types",
- "alloy-transport 0.8.3",
+ "alloy-transport 0.9.1",
  "futures",
  "futures-util",
  "thiserror 2.0.8",
@@ -330,6 +330,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip7702"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "serde",
+]
+
+[[package]]
 name = "alloy-eips"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,15 +380,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9fadfe089e9ccc0650473f2d4ef0a28bc015bbca5631d9f0f09e49b557fdb3"
+checksum = "938bc1cf2ec42579e187834efc254e76dd3fa19f526b57872713e6b95f411305"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702 0.4.2",
+ "alloy-eip7702 0.5.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.8.3",
+ "alloy-serde 0.9.1",
  "c-kzg",
  "derive_more",
  "once_cell",
@@ -398,12 +410,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2a4cf7b70f3495788e74ce1c765260ffe38820a2a774ff4aacb62e31ea73f9"
+checksum = "b648eac186485ead3da160985b929e610a45eb39903f750da9b35f58a91eef52"
 dependencies = [
+ "alloy-eips 0.9.1",
  "alloy-primitives",
- "alloy-serde 0.8.3",
+ "alloy-serde 0.9.1",
  "alloy-trie",
  "serde",
 ]
@@ -450,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29040b9d5fe2fb70415531882685b64f8efd08dfbd6cc907120650504821105"
+checksum = "a1a38b4b49667a84ecad7cdaf431b8bd3f14ca496e5a021df1c26d5c4595dca6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -510,20 +523,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510cc00b318db0dfccfdd2d032411cfae64fc144aef9679409e014145d3dacc4"
+checksum = "4fb5dc326960e88eec6b5e9add221a071f15cb8fa93b9e88ee9c76cd0e4e1009"
 dependencies = [
- "alloy-consensus 0.8.3",
- "alloy-consensus-any 0.8.3",
- "alloy-eips 0.8.3",
- "alloy-json-rpc 0.8.3",
- "alloy-network-primitives 0.8.3",
+ "alloy-consensus 0.9.1",
+ "alloy-consensus-any 0.9.1",
+ "alloy-eips 0.9.1",
+ "alloy-json-rpc 0.9.1",
+ "alloy-network-primitives 0.9.1",
  "alloy-primitives",
- "alloy-rpc-types-any 0.8.3",
- "alloy-rpc-types-eth 0.8.3",
- "alloy-serde 0.8.3",
- "alloy-signer 0.8.3",
+ "alloy-rpc-types-any 0.9.1",
+ "alloy-rpc-types-eth 0.9.1",
+ "alloy-serde 0.9.1",
+ "alloy-signer 0.9.1",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -560,24 +573,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9081c099e798b8a2bba2145eb82a9a146f01fc7a35e9ab6e7b43305051f97550"
+checksum = "1535c89ae0648f2c15c0bf9b8b92670f6b3b8515b645425c8b46462563c0eae4"
 dependencies = [
- "alloy-consensus 0.8.3",
- "alloy-eips 0.8.3",
+ "alloy-consensus 0.9.1",
+ "alloy-eips 0.9.1",
  "alloy-primitives",
- "alloy-serde 0.8.3",
+ "alloy-serde 0.9.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef9849fb8bbb28f69f2cbdb4b0dac2f0e35c04f6078a00dfb8486469aed02de"
+checksum = "5af000a8d9aa22694c92a5c6ebd9113495d2eb78fb3579d02a715569b973cc26"
 dependencies = [
- "alloy-genesis 0.8.3",
+ "alloy-genesis 0.9.1",
  "alloy-primitives",
  "k256",
  "rand",
@@ -661,27 +674,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2dfaddd9a30aa870a78a4e1316e3e115ec1e12e552cbc881310456b85c1f24"
+checksum = "a9a9d6ef38d75e4b0dce6737463099698f9b839d1c3f7c8883bfdfce8954374b"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.8.3",
- "alloy-eips 0.8.3",
- "alloy-json-rpc 0.8.3",
- "alloy-network 0.8.3",
- "alloy-network-primitives 0.8.3",
+ "alloy-consensus 0.9.1",
+ "alloy-eips 0.9.1",
+ "alloy-json-rpc 0.9.1",
+ "alloy-network 0.9.1",
+ "alloy-network-primitives 0.9.1",
  "alloy-node-bindings",
  "alloy-primitives",
- "alloy-pubsub 0.8.3",
- "alloy-rpc-client 0.8.3",
- "alloy-rpc-types-anvil 0.8.3",
- "alloy-rpc-types-eth 0.8.3",
- "alloy-signer 0.8.3",
- "alloy-signer-local 0.8.3",
- "alloy-transport 0.8.3",
- "alloy-transport-http 0.8.3",
- "alloy-transport-ws 0.8.3",
+ "alloy-pubsub 0.9.1",
+ "alloy-rpc-client 0.9.1",
+ "alloy-rpc-types-anvil 0.9.1",
+ "alloy-rpc-types-eth 0.9.1",
+ "alloy-signer 0.9.1",
+ "alloy-signer-local 0.9.1",
+ "alloy-transport 0.9.1",
+ "alloy-transport-http 0.9.1",
+ "alloy-transport-ws 0.9.1",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -723,13 +736,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695809e743628d54510c294ad17a4645bd9f465aeb0d20ee9ce9877c9712dc9c"
+checksum = "1be3b30bab565198a1bda090915dd165ca9211154eb0b37d046a22829418dcc0"
 dependencies = [
- "alloy-json-rpc 0.8.3",
+ "alloy-json-rpc 0.9.1",
  "alloy-primitives",
- "alloy-transport 0.8.3",
+ "alloy-transport 0.9.1",
  "bimap",
  "futures",
  "serde",
@@ -789,16 +802,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531137b283547d5b9a5cafc96b006c64ef76810c681d606f28be9781955293b6"
+checksum = "f5ed1e9957edfc8d155e2610e2ff3e10b059b89a6103de9f01579f40d8926d47"
 dependencies = [
- "alloy-json-rpc 0.8.3",
+ "alloy-json-rpc 0.9.1",
  "alloy-primitives",
- "alloy-pubsub 0.8.3",
- "alloy-transport 0.8.3",
- "alloy-transport-http 0.8.3",
- "alloy-transport-ws 0.8.3",
+ "alloy-pubsub 0.9.1",
+ "alloy-transport 0.9.1",
+ "alloy-transport-http 0.9.1",
+ "alloy-transport-ws 0.9.1",
  "futures",
  "pin-project",
  "reqwest 0.12.9",
@@ -827,15 +840,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3410a472ce26c457e9780f708ee6bd540b30f88f1f31fdab7a11d00bd6aa1aee"
+checksum = "206749723862bd27d5468270e30fc987c5b4376240aefee728d7e64282c9d146"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-anvil 0.8.3",
- "alloy-rpc-types-engine 0.8.3",
- "alloy-rpc-types-eth 0.8.3",
- "alloy-serde 0.8.3",
+ "alloy-rpc-types-anvil 0.9.1",
+ "alloy-rpc-types-engine 0.9.1",
+ "alloy-rpc-types-eth 0.9.1",
+ "alloy-serde 0.9.1",
  "serde",
 ]
 
@@ -865,13 +878,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed06bd8a5fc57b352a6cbac24eec52a4760f08ae2c1eb56ac49c8ed4b02c351"
+checksum = "4ac98a9d17ec4d851ea38e556c27b92e1ff8c97664cf1feb77aec38dcba34579"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 0.8.3",
- "alloy-serde 0.8.3",
+ "alloy-rpc-types-eth 0.9.1",
+ "alloy-serde 0.9.1",
  "serde",
 ]
 
@@ -888,13 +901,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed98e1af55a7d856bfa385f30f63d8d56be2513593655c904a8f4a7ec963aa3e"
+checksum = "5e6ff23d7bde6ddeea4c1ca98e7a5a728326d543bd7133735c04ea83ebde41d0"
 dependencies = [
- "alloy-consensus-any 0.8.3",
- "alloy-rpc-types-eth 0.8.3",
- "alloy-serde 0.8.3",
+ "alloy-consensus-any 0.9.1",
+ "alloy-rpc-types-eth 0.9.1",
+ "alloy-serde 0.9.1",
 ]
 
 [[package]]
@@ -943,15 +956,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03bd16fa4959255ebf4a7702df08f325e5631df5cdca07c8a8e58bdc10fe02e3"
+checksum = "ee96e9793d3ec528ead6e8580f24e9acc71f5c2bc35feefba24465044bb77d76"
 dependencies = [
- "alloy-consensus 0.8.3",
- "alloy-eips 0.8.3",
+ "alloy-consensus 0.9.1",
+ "alloy-eips 0.9.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.8.3",
+ "alloy-serde 0.9.1",
  "derive_more",
  "serde",
  "strum 0.26.3",
@@ -1002,22 +1015,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8737d7a6e37ca7bba9c23e9495c6534caec6760eb24abc9d5ffbaaba147818e1"
+checksum = "319a0ca31863bd6fb9aafeaa16425d0a2f1228da44bc24fd2f997ba50afe7e18"
 dependencies = [
- "alloy-consensus 0.8.3",
- "alloy-consensus-any 0.8.3",
- "alloy-eips 0.8.3",
- "alloy-network-primitives 0.8.3",
+ "alloy-consensus 0.9.1",
+ "alloy-consensus-any 0.9.1",
+ "alloy-eips 0.9.1",
+ "alloy-network-primitives 0.9.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.8.3",
+ "alloy-serde 0.9.1",
  "alloy-sol-types",
- "derive_more",
  "itertools 0.13.0",
  "serde",
  "serde_json",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
@@ -1085,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5851bf8d5ad33014bd0c45153c603303e730acc8a209450a7ae6b4a12c2789e2"
+checksum = "81537867986734e5867a9131145bdc56301f5b37ef9c9fb4654d7f7691a4015d"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -1124,9 +1137,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e10ca565da6500cca015ba35ee424d59798f2e1b85bc0dd8f81dafd401f029a"
+checksum = "0fdcbfe7079c877b3cb6ec43017e94f66432480f1c1779f736c064e6a8d422cc"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -1172,14 +1185,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47fababf5a745133490cde927d48e50267f97d3d1209b9fc9f1d1d666964d172"
+checksum = "3f5175bd063463e25f1ffc6daaa223db15baf4b18e3d83d0d31fb95756aab6cc"
 dependencies = [
- "alloy-consensus 0.8.3",
- "alloy-network 0.8.3",
+ "alloy-consensus 0.9.1",
+ "alloy-network 0.9.1",
  "alloy-primitives",
- "alloy-signer 0.8.3",
+ "alloy-signer 0.9.1",
  "async-trait",
  "eth-keystore",
  "k256",
@@ -1282,11 +1295,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538a04a37221469cac0ce231b737fd174de2fdfcdd843bdd068cb39ed3e066ad"
+checksum = "6121c7a8791d7984bd3e1a487aae55c62358b0bd94330126db41d795d942e24e"
 dependencies = [
- "alloy-json-rpc 0.8.3",
+ "alloy-json-rpc 0.9.1",
  "base64 0.22.1",
  "futures-util",
  "futures-utils-wasm",
@@ -1317,12 +1330,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed40eb1e1265b2911512f6aa1dcece9702d078f5a646730c45e39e2be00ac1c"
+checksum = "15487cd2d7f2bfd8546e851d80db470603c2a1de82f7c39403078356b20d9a21"
 dependencies = [
- "alloy-json-rpc 0.8.3",
- "alloy-transport 0.8.3",
+ "alloy-json-rpc 0.9.1",
+ "alloy-transport 0.9.1",
  "reqwest 0.12.9",
  "serde_json",
  "tower 0.5.2",
@@ -1350,12 +1363,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba0e39d181d13c266dbb8ca54ed584a2c66d6e9279afca89c7a6b1825e98abb"
+checksum = "f812a1f1ae7955964727d3040bf240955ca324d80383b9dd0ab21a6de3007386"
 dependencies = [
- "alloy-pubsub 0.8.3",
- "alloy-transport 0.8.3",
+ "alloy-pubsub 0.9.1",
+ "alloy-transport 0.9.1",
  "futures",
  "http 1.2.0",
  "rustls",
@@ -7775,7 +7788,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7848,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7877,7 +7890,7 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7917,7 +7930,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7951,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7967,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7996,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 0.7.3",
@@ -8016,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-genesis 0.7.3",
  "clap",
@@ -8030,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "ahash",
  "alloy-consensus 0.7.3",
@@ -8092,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8102,7 +8115,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -8120,7 +8133,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8139,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -8150,7 +8163,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8164,7 +8177,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8178,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8193,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8217,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives",
@@ -8250,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-genesis 0.7.3",
@@ -8277,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-genesis 0.7.3",
@@ -8306,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -8322,7 +8335,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8348,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8372,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8396,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8427,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8458,7 +8471,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives",
@@ -8490,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives",
@@ -8511,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "futures",
  "pin-project",
@@ -8535,7 +8548,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8578,7 +8591,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8611,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -8624,7 +8637,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8652,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 0.7.3",
@@ -8673,7 +8686,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "eyre",
  "reth-chainspec",
@@ -8683,7 +8696,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8699,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -8719,7 +8732,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8739,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8765,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8775,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8802,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8821,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -8837,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8855,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8891,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -8906,7 +8919,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "serde",
  "serde_json",
@@ -8916,7 +8929,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives",
@@ -8943,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8964,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -8981,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "bindgen",
  "cc",
@@ -8990,7 +9003,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "futures",
  "metrics",
@@ -9002,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
 ]
@@ -9010,7 +9023,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9024,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9078,7 +9091,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -9101,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9124,7 +9137,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9139,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -9153,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9170,7 +9183,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-rpc-types-engine 0.7.3",
  "eyre",
@@ -9191,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives",
@@ -9255,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9305,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "eyre",
  "reth-basic-payload-builder",
@@ -9333,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9357,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "eyre",
  "http 1.2.0",
@@ -9379,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9391,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9413,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-rpc-types 0.7.3",
  "async-trait",
@@ -9432,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-rpc-types-engine 0.7.3",
  "async-trait",
@@ -9446,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -9464,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives",
@@ -9474,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-rpc-types 0.7.3",
  "reth-chainspec",
@@ -9485,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9519,7 +9532,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9544,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9590,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9619,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9634,7 +9647,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -9651,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-dyn-abi",
@@ -9721,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-json-rpc 0.7.3",
@@ -9746,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "http 1.2.0",
  "jsonrpsee",
@@ -9782,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -9815,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-dyn-abi",
@@ -9859,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9901,7 +9914,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-rpc-types-engine 0.7.3",
  "http 1.2.0",
@@ -9915,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -9931,7 +9944,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9948,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -9986,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -10013,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10027,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10048,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10060,7 +10073,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -10085,7 +10098,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives",
@@ -10099,7 +10112,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10117,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10127,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "clap",
  "eyre",
@@ -10142,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -10180,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -10206,7 +10219,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-genesis 0.7.3",
@@ -10232,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10253,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10276,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10291,7 +10304,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.4#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=0ac4475#15fac0873e91ea29ab2e605bfba17bedcd7a6084"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ significant_drop_tightening = "allow"
 anyhow = { version = "1", default-features = false }
 axum = { version = "0", features = ["http2", "tokio", "json"], default-features = false }
 # only include features that we know can be compiled into zkvm program
-alloy = { version = "0.8", features = ["sol-types"], default-features = false }
+alloy = { version = "0.9", features = ["sol-types"], default-features = false }
 # Hacks to play happy with reth types, we normally use the alloy facade crate
 alloy-eips = { version = "0.7.3", default-features = false }
 alloy-consensus = { version = "0.7.3"}
@@ -176,18 +176,18 @@ prost = { version = "0.13", features = ["derive", "std"], default-features = fal
 # q
 # r
 rand = { version = "0.8", default-features = false }
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4" }
-reth-db = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", features = ["mdbx"], default-features = false }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", features = ["std", "alloy"], default-features = false }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
-reth-ethereum-payload-builder= { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.4", default-features = false }
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475" }
+reth-db = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", features = ["mdbx"], default-features = false }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", features = ["std", "alloy"], default-features = false }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
+reth-ethereum-payload-builder= { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "0ac4475", default-features = false }
 revm = "18"
 
 # s

--- a/examples/clob/programs/program/Cargo.lock
+++ b/examples/clob/programs/program/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4305e0397a7eb57f4840a048583b7ab904eabd250264568fc65a7e38a76c9e40"
+dependencies = [
+ "alloy-core",
+]
+
+[[package]]
 name = "alloy-core"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +186,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 name = "clob-core"
 version = "0.1.0"
 dependencies = [
- "alloy",
+ "alloy 0.9.1",
  "borsh",
  "ivm-abi",
  "serde",
@@ -188,7 +197,7 @@ dependencies = [
 name = "clob-sp1-guest"
 version = "0.1.0"
 dependencies = [
- "alloy",
+ "alloy 0.8.0",
  "borsh",
  "clob-core",
  "ivm-abi",
@@ -341,7 +350,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 name = "ivm-abi"
 version = "0.0.1"
 dependencies = [
- "alloy",
+ "alloy 0.9.1",
 ]
 
 [[package]]

--- a/examples/matching-game/programs/program/Cargo.lock
+++ b/examples/matching-game/programs/program/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4305e0397a7eb57f4840a048583b7ab904eabd250264568fc65a7e38a76c9e40"
+dependencies = [
+ "alloy-core",
+]
+
+[[package]]
 name = "alloy-core"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,7 +361,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 name = "ivm-abi"
 version = "0.0.1"
 dependencies = [
- "alloy",
+ "alloy 0.9.1",
 ]
 
 [[package]]
@@ -388,7 +397,7 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 name = "matching-game-core"
 version = "0.1.0"
 dependencies = [
- "alloy",
+ "alloy 0.9.1",
  "bincode",
  "borsh",
  "kairos-trie",
@@ -400,7 +409,7 @@ dependencies = [
 name = "matching-game-sp1-guest"
 version = "0.1.0"
 dependencies = [
- "alloy",
+ "alloy 0.8.0",
  "bincode",
  "ivm-abi",
  "kairos-trie",


### PR DESCRIPTION
Update reth and alloy deps. There seems to be some implicit feature gating updates that will help ivm lib consumers build ivm deps and reth deps in the same workspace