### PR TITLE
fix: fixes broken link to Dockerfile

### DIFF
--- a/book/src/coprocessor/run.md
+++ b/book/src/coprocessor/run.md
@@ -2,7 +2,7 @@
 
 ## Docker
 
-We do not yet have a public docker repository, but you can build [this docker image](https://github.com/InfinityVM/InfinityVM/blob/main/Dockerfile.coproc-node) located in the InfinityVM repo.
+We do not yet have a public docker repository, but you can build [this docker image](https://github.com/InfinityVM/InfinityVM/blob/main/Dockerfile.coprocessor-node) located in the InfinityVM repo.
 
 ## Build from source
 


### PR DESCRIPTION
## What

Fixes a broken link to the coprocessor dockerfile  in the generated mdbook.