### PR TITLE
feat: starts node_exporter as well as reth on startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@
 !Cargo.lock
 !Cargo.toml
 !.cargo
+!entrypoint*

--- a/Dockerfile.exec
+++ b/Dockerfile.exec
@@ -28,10 +28,12 @@ RUN apt-get update && \
 
 COPY --from=builder /app/target/release/ivm-exec /usr/local/bin/reth
 COPY --from=grafana/promtail:3.0.0 /usr/bin/promtail /usr/local/bin
+COPY --from=prom/node-exporter:v1.8.2 /bin/node_exporter /usr/local/bin/node_exporter
+COPY entrypoint-exec.sh /usr/local/bin/entrypoint.sh
 
 RUN chmod +x /usr/local/bin/reth
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
-COPY --from=prom/node-exporter:v1.8.2 /bin/node_exporter /usr/local/bin/node_exporter
+EXPOSE  8545 8546 9001 9100 30303 30303/udp 
 
-EXPOSE 30303 30303/udp 9001 8545 8546
-ENTRYPOINT ["/usr/local/bin/reth"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/entrypoint-exec.sh
+++ b/entrypoint-exec.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+node_exporter &
+
+exec /usr/local/bin/reth


### PR DESCRIPTION
# What

As a part of https://github.com/InfinityVM/infra/issues/74

Exposes port `9100`
Adds an entrypoint.sh script to run `node_exporter` as a background service, as well as `reth` - the main service, on startup