### PR TITLE
chore(deps): don't use facade crates in `ivm-exec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+dependencies = [
+ "fastrand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1540,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1658,6 +1668,145 @@ dependencies = [
 ]
 
 [[package]]
+name = "boa_ast"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
+dependencies = [
+ "bitflags 2.6.0",
+ "boa_interner",
+ "boa_macros",
+ "boa_string",
+ "indexmap 2.7.0",
+ "num-bigint 0.4.6",
+ "rustc-hash 2.1.0",
+]
+
+[[package]]
+name = "boa_engine"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.6.0",
+ "boa_ast",
+ "boa_gc",
+ "boa_interner",
+ "boa_macros",
+ "boa_parser",
+ "boa_profiler",
+ "boa_string",
+ "bytemuck",
+ "cfg-if 1.0.0",
+ "dashmap",
+ "fast-float2",
+ "hashbrown 0.15.2",
+ "icu_normalizer",
+ "indexmap 2.7.0",
+ "intrusive-collections",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "num_enum 0.7.3",
+ "once_cell",
+ "pollster",
+ "portable-atomic",
+ "rand",
+ "regress",
+ "rustc-hash 2.1.0",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "sptr",
+ "static_assertions",
+ "tap",
+ "thin-vec",
+ "thiserror 2.0.8",
+ "time",
+]
+
+[[package]]
+name = "boa_gc"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2425c0b7720d42d73eaa6a883fbb77a5c920da8694964a3d79a67597ac55cce2"
+dependencies = [
+ "boa_macros",
+ "boa_profiler",
+ "boa_string",
+ "hashbrown 0.15.2",
+ "thin-vec",
+]
+
+[[package]]
+name = "boa_interner"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
+dependencies = [
+ "boa_gc",
+ "boa_macros",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.0",
+ "once_cell",
+ "phf",
+ "rustc-hash 2.1.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "boa_macros"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
+]
+
+[[package]]
+name = "boa_parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
+dependencies = [
+ "bitflags 2.6.0",
+ "boa_ast",
+ "boa_interner",
+ "boa_macros",
+ "boa_profiler",
+ "fast-float2",
+ "icu_properties",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "regress",
+ "rustc-hash 2.1.0",
+]
+
+[[package]]
+name = "boa_profiler"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4064908e7cdf9b6317179e9b04dcb27f1510c1c144aeab4d0394014f37a0f922"
+
+[[package]]
+name = "boa_string"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
+dependencies = [
+ "fast-float2",
+ "paste",
+ "rustc-hash 2.1.0",
+ "sptr",
+ "static_assertions",
+]
+
+[[package]]
 name = "borsh"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1870,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.9",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1897,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "byteorder"
@@ -1798,6 +1972,21 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1934,7 +2123,7 @@ dependencies = [
  "eyre",
  "ivm-contracts",
  "ivm-test-utils",
- "reqwest 0.12.9",
+ "reqwest 0.11.27",
  "serde",
  "tokio",
 ]
@@ -2082,6 +2271,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+dependencies = [
+ "crossterm",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if 1.0.0",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concat-kdf"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,7 +2314,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2262,6 +2477,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "mio 1.0.3",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2927,7 +3167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3001,6 +3241,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -3827,6 +4073,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3917,6 +4169,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4219,9 +4484,15 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inotify"
@@ -4254,6 +4525,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "894813a444908c0c8c0e221b041771d107c4a21de1d317dc49bcc66e3c9e5b3f"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "intensity-test-programs"
 version = "0.1.0"
 dependencies = [
@@ -4275,6 +4559,15 @@ dependencies = [
  "tokio",
  "widestring",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
 ]
 
 [[package]]
@@ -4443,7 +4736,9 @@ dependencies = [
  "clap",
  "eyre",
  "k256",
+ "reth",
  "reth-chainspec",
+ "reth-ethereum-cli",
  "reth-ethereum-engine-primitives",
  "reth-evm",
  "reth-evm-ethereum",
@@ -4451,11 +4746,14 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-node-ethereum",
+ "reth-payload-validator",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
+ "reth-tasks",
+ "reth-transaction-pool",
  "revm",
  "serde",
  "tokio",
@@ -4509,7 +4807,7 @@ dependencies = [
  "matching-game-programs",
  "matching-game-server",
  "mock-consumer-programs",
- "reqwest 0.12.9",
+ "reqwest 0.11.27",
  "serde_json",
  "tempfile",
  "tokio",
@@ -4936,7 +5234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5091,7 +5389,7 @@ dependencies = [
  "ivm-test-utils",
  "mock-consumer-programs",
  "once_cell",
- "reqwest 0.12.9",
+ "reqwest 0.11.27",
  "tokio",
  "tracing",
  "url",
@@ -5197,7 +5495,7 @@ dependencies = [
  "matching-game-core",
  "matching-game-programs",
  "mime",
- "reqwest 0.12.9",
+ "reqwest 0.11.27",
  "serde",
  "tempfile",
  "tokio",
@@ -5226,6 +5524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -5359,6 +5666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -5589,6 +5897,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -5718,6 +6027,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -6319,6 +6629,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6374,6 +6726,12 @@ checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "polyval"
@@ -6646,8 +7004,8 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -6669,7 +7027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -6805,7 +7163,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6861,6 +7219,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags 2.6.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6972,6 +7351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "regress"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1541daf4e4ed43a0922b7969bdc2170178bcacc5dabf7e39bc508a9fa3953a7a"
+dependencies = [
+ "hashbrown 0.14.5",
+ "memchr",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6989,19 +7378,23 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower-service",
  "url",
@@ -7019,16 +7412,14 @@ checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.2",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -7040,13 +7431,12 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -7067,6 +7457,76 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
+]
+
+[[package]]
+name = "reth"
+version = "1.1.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-eips 0.9.2",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "aquamarine",
+ "backon",
+ "clap",
+ "eyre",
+ "futures",
+ "reth-basic-payload-builder",
+ "reth-chainspec",
+ "reth-cli",
+ "reth-cli-commands",
+ "reth-cli-runner",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-db",
+ "reth-db-api",
+ "reth-downloaders",
+ "reth-errors",
+ "reth-ethereum-cli",
+ "reth-ethereum-payload-builder",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-exex",
+ "reth-fs-util",
+ "reth-network",
+ "reth-network-api",
+ "reth-network-p2p",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-node-events",
+ "reth-node-metrics",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune",
+ "reth-revm",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types-compat",
+ "reth-stages",
+ "reth-static-file",
+ "reth-tasks",
+ "reth-tracing",
+ "reth-transaction-pool",
+ "reth-trie",
+ "reth-trie-db",
+ "serde_json",
+ "similar-asserts",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7145,6 +7605,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-cli"
+version = "1.1.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
+dependencies = [
+ "alloy-genesis",
+ "clap",
+ "eyre",
+ "reth-cli-runner",
+ "reth-db",
+ "serde_json",
+ "shellexpand",
+]
+
+[[package]]
+name = "reth-cli-commands"
+version = "1.1.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
+dependencies = [
+ "ahash",
+ "alloy-consensus 0.9.2",
+ "alloy-eips 0.9.2",
+ "alloy-primitives",
+ "alloy-rlp",
+ "backon",
+ "clap",
+ "comfy-table",
+ "crossterm",
+ "eyre",
+ "fdlimit",
+ "futures",
+ "human_bytes",
+ "itertools 0.13.0",
+ "ratatui",
+ "reth-chainspec",
+ "reth-cli",
+ "reth-cli-runner",
+ "reth-cli-util",
+ "reth-codecs",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-db-common",
+ "reth-downloaders",
+ "reth-ecies",
+ "reth-eth-wire",
+ "reth-ethereum-cli",
+ "reth-ethereum-consensus",
+ "reth-evm",
+ "reth-exex",
+ "reth-fs-util",
+ "reth-network",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-events",
+ "reth-node-metrics",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages",
+ "reth-static-file",
+ "reth-static-file-types",
+ "reth-trie",
+ "reth-trie-db",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "reth-cli-runner"
+version = "1.1.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
+dependencies = [
+ "reth-tasks",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "reth-cli-util"
 version = "1.1.5"
 source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
@@ -7159,6 +7705,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "thiserror 2.0.8",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -7709,6 +8256,16 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "thiserror 2.0.8",
+]
+
+[[package]]
+name = "reth-ethereum-cli"
+version = "1.1.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
+dependencies = [
+ "eyre",
+ "reth-chainspec",
+ "reth-cli",
 ]
 
 [[package]]
@@ -8394,6 +8951,7 @@ dependencies = [
  "procfs 0.16.0",
  "reth-metrics",
  "reth-tasks",
+ "tikv-jemalloc-ctl",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -9077,6 +9635,7 @@ version = "1.1.5"
 source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
 dependencies = [
  "alloy-primitives",
+ "clap",
  "derive_more",
  "serde",
  "strum 0.26.3",
@@ -9347,6 +9906,8 @@ dependencies = [
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
+ "boa_engine",
+ "boa_gc",
  "colorchoice",
  "revm",
  "serde_json",
@@ -9613,7 +10174,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9638,10 +10199,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -9723,6 +10293,12 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
 
 [[package]]
 name = "salsa20"
@@ -10126,6 +10702,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 1.0.3",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10142,6 +10739,27 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core",
+]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
+dependencies = [
+ "console",
+ "serde",
+ "similar",
 ]
 
 [[package]]
@@ -10166,6 +10784,12 @@ dependencies = [
  "termcolor",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "size"
@@ -10646,6 +11270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10819,18 +11449,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -10838,16 +11457,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -10875,7 +11484,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10886,6 +11495,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
@@ -10947,6 +11562,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10954,6 +11600,7 @@ checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -11569,6 +12216,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11882,7 +12546,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,6 +4737,7 @@ dependencies = [
  "k256",
  "reth",
  "reth-chainspec",
+ "reth-cli-util",
  "reth-ethereum-cli",
  "reth-ethereum-engine-primitives",
  "reth-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,16 +1449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backon"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
-dependencies = [
- "fastrand",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,145 +1658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boa_ast"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
-dependencies = [
- "bitflags 2.6.0",
- "boa_interner",
- "boa_macros",
- "boa_string",
- "indexmap 2.7.0",
- "num-bigint 0.4.6",
- "rustc-hash 2.1.0",
-]
-
-[[package]]
-name = "boa_engine"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
-dependencies = [
- "arrayvec",
- "bitflags 2.6.0",
- "boa_ast",
- "boa_gc",
- "boa_interner",
- "boa_macros",
- "boa_parser",
- "boa_profiler",
- "boa_string",
- "bytemuck",
- "cfg-if 1.0.0",
- "dashmap",
- "fast-float2",
- "hashbrown 0.15.2",
- "icu_normalizer",
- "indexmap 2.7.0",
- "intrusive-collections",
- "itertools 0.13.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "num_enum 0.7.3",
- "once_cell",
- "pollster",
- "portable-atomic",
- "rand",
- "regress",
- "rustc-hash 2.1.0",
- "ryu-js",
- "serde",
- "serde_json",
- "sptr",
- "static_assertions",
- "tap",
- "thin-vec",
- "thiserror 2.0.8",
- "time",
-]
-
-[[package]]
-name = "boa_gc"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c0b7720d42d73eaa6a883fbb77a5c920da8694964a3d79a67597ac55cce2"
-dependencies = [
- "boa_macros",
- "boa_profiler",
- "boa_string",
- "hashbrown 0.15.2",
- "thin-vec",
-]
-
-[[package]]
-name = "boa_interner"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
-dependencies = [
- "boa_gc",
- "boa_macros",
- "hashbrown 0.15.2",
- "indexmap 2.7.0",
- "once_cell",
- "phf",
- "rustc-hash 2.1.0",
- "static_assertions",
-]
-
-[[package]]
-name = "boa_macros"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
- "synstructure",
-]
-
-[[package]]
-name = "boa_parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
-dependencies = [
- "bitflags 2.6.0",
- "boa_ast",
- "boa_interner",
- "boa_macros",
- "boa_profiler",
- "fast-float2",
- "icu_properties",
- "num-bigint 0.4.6",
- "num-traits",
- "regress",
- "rustc-hash 2.1.0",
-]
-
-[[package]]
-name = "boa_profiler"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4064908e7cdf9b6317179e9b04dcb27f1510c1c144aeab4d0394014f37a0f922"
-
-[[package]]
-name = "boa_string"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
-dependencies = [
- "fast-float2",
- "paste",
- "rustc-hash 2.1.0",
- "sptr",
- "static_assertions",
-]
-
-[[package]]
 name = "borsh"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,17 +1721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
-dependencies = [
- "memchr",
- "regex-automata 0.4.9",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,20 +1737,6 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
 
 [[package]]
 name = "byteorder"
@@ -1972,21 +1798,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
-name = "castaway"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -2271,32 +2082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "comfy-table"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
-dependencies = [
- "crossterm",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
-dependencies = [
- "castaway",
- "cfg-if 1.0.0",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "concat-kdf"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,7 +2099,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.59.0",
 ]
 
@@ -2477,31 +2262,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.6.0",
- "crossterm_winapi",
- "mio 1.0.3",
- "parking_lot",
- "rustix",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "crunchy"
@@ -3241,12 +3001,6 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
-
-[[package]]
-name = "fast-float2"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -4073,12 +3827,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "human_bytes"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,15 +4219,9 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "web-time",
 ]
-
-[[package]]
-name = "indoc"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inotify"
@@ -4512,20 +4254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instability"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898e106451f7335950c9cc64f8ec67b5f65698679ac67ed00619aeef14e1cf75"
-dependencies = [
- "darling",
- "indoc",
- "pretty_assertions",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "intensity-test-programs"
 version = "0.1.0"
 dependencies = [
@@ -4547,15 +4275,6 @@ dependencies = [
  "tokio",
  "widestring",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "intrusive-collections"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
 ]
 
 [[package]]
@@ -4719,19 +4438,24 @@ dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
  "alloy-network 0.9.2",
+ "alloy-rpc-types",
  "alloy-signer-local 0.9.2",
  "clap",
  "eyre",
  "k256",
- "reth",
+ "reth-chainspec",
  "reth-ethereum-engine-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-network",
  "reth-node-api",
+ "reth-node-builder",
  "reth-node-ethereum",
+ "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
+ "reth-rpc",
  "revm",
  "serde",
  "tokio",
@@ -5505,15 +5229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "memuse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5644,7 +5359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -5875,7 +5589,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -6005,7 +5718,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -6607,48 +6319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6704,12 +6374,6 @@ checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
 dependencies = [
  "crunchy",
 ]
-
-[[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "polyval"
@@ -7200,27 +6864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
-dependencies = [
- "bitflags 2.6.0",
- "cassowary",
- "compact_str",
- "crossterm",
- "instability",
- "itertools 0.13.0",
- "lru",
- "paste",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "raw-cpuid"
 version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7329,16 +6972,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "regress"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1541daf4e4ed43a0922b7969bdc2170178bcacc5dabf7e39bc508a9fa3953a7a"
-dependencies = [
- "hashbrown 0.14.5",
- "memchr",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7437,76 +7070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
-dependencies = [
- "alloy-consensus 0.9.2",
- "alloy-eips 0.9.2",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
- "aquamarine",
- "backon",
- "clap",
- "eyre",
- "futures",
- "reth-basic-payload-builder",
- "reth-chainspec",
- "reth-cli",
- "reth-cli-commands",
- "reth-cli-runner",
- "reth-cli-util",
- "reth-config",
- "reth-consensus",
- "reth-consensus-common",
- "reth-db",
- "reth-db-api",
- "reth-downloaders",
- "reth-errors",
- "reth-ethereum-cli",
- "reth-ethereum-payload-builder",
- "reth-evm",
- "reth-execution-types",
- "reth-exex",
- "reth-fs-util",
- "reth-network",
- "reth-network-api",
- "reth-network-p2p",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-node-events",
- "reth-node-metrics",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-payload-validator",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune",
- "reth-revm",
- "reth-rpc",
- "reth-rpc-api",
- "reth-rpc-builder",
- "reth-rpc-eth-types",
- "reth-rpc-server-types",
- "reth-rpc-types-compat",
- "reth-stages",
- "reth-static-file",
- "reth-tasks",
- "reth-tracing",
- "reth-transaction-pool",
- "reth-trie",
- "reth-trie-db",
- "serde_json",
- "similar-asserts",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "reth-basic-payload-builder"
 version = "1.1.5"
 source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
@@ -7582,92 +7145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-cli"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
-dependencies = [
- "alloy-genesis",
- "clap",
- "eyre",
- "reth-cli-runner",
- "reth-db",
- "serde_json",
- "shellexpand",
-]
-
-[[package]]
-name = "reth-cli-commands"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
-dependencies = [
- "ahash",
- "alloy-consensus 0.9.2",
- "alloy-eips 0.9.2",
- "alloy-primitives",
- "alloy-rlp",
- "backon",
- "clap",
- "comfy-table",
- "crossterm",
- "eyre",
- "fdlimit",
- "futures",
- "human_bytes",
- "itertools 0.13.0",
- "ratatui",
- "reth-chainspec",
- "reth-cli",
- "reth-cli-runner",
- "reth-cli-util",
- "reth-codecs",
- "reth-config",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
- "reth-db-common",
- "reth-downloaders",
- "reth-ecies",
- "reth-eth-wire",
- "reth-ethereum-cli",
- "reth-ethereum-consensus",
- "reth-evm",
- "reth-exex",
- "reth-fs-util",
- "reth-network",
- "reth-network-p2p",
- "reth-network-peers",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-events",
- "reth-node-metrics",
- "reth-primitives",
- "reth-provider",
- "reth-prune",
- "reth-stages",
- "reth-static-file",
- "reth-static-file-types",
- "reth-trie",
- "reth-trie-db",
- "secp256k1",
- "serde",
- "serde_json",
- "tokio",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "reth-cli-runner"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
-dependencies = [
- "reth-tasks",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "reth-cli-util"
 version = "1.1.5"
 source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
@@ -7682,7 +7159,6 @@ dependencies = [
  "secp256k1",
  "serde",
  "thiserror 2.0.8",
- "tikv-jemallocator",
 ]
 
 [[package]]
@@ -8233,16 +7709,6 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "thiserror 2.0.8",
-]
-
-[[package]]
-name = "reth-ethereum-cli"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
-dependencies = [
- "eyre",
- "reth-chainspec",
- "reth-cli",
 ]
 
 [[package]]
@@ -8928,7 +8394,6 @@ dependencies = [
  "procfs 0.16.0",
  "reth-metrics",
  "reth-tasks",
- "tikv-jemalloc-ctl",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -9612,7 +9077,6 @@ version = "1.1.5"
 source = "git+https://github.com/paradigmxyz/reth.git?rev=28d5231#28d52312acd46be2bfc46661a7b392feaa2bd4c5"
 dependencies = [
  "alloy-primitives",
- "clap",
  "derive_more",
  "serde",
  "strum 0.26.3",
@@ -9883,8 +9347,6 @@ dependencies = [
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
- "boa_engine",
- "boa_gc",
  "colorchoice",
  "revm",
  "serde_json",
@@ -10261,12 +9723,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "ryu-js"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
 
 [[package]]
 name = "salsa20"
@@ -10670,27 +10126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
-dependencies = [
- "libc",
- "mio 1.0.3",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10707,27 +10142,6 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core",
-]
-
-[[package]]
-name = "similar"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
-dependencies = [
- "console",
- "serde",
- "similar",
 ]
 
 [[package]]
@@ -10752,12 +10166,6 @@ dependencies = [
  "termcolor",
  "time",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "size"
@@ -11238,12 +10646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11486,12 +10888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thin-vec"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11551,37 +10947,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-ctl"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
-dependencies = [
- "libc",
- "paste",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11589,7 +10954,6 @@ checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -12203,23 +11567,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,6 @@ dependencies = [
  "alloy-contract",
  "alloy-core",
  "alloy-eips 0.9.2",
- "alloy-genesis",
  "alloy-network 0.9.2",
  "alloy-node-bindings",
  "alloy-provider",
@@ -4727,10 +4726,10 @@ dependencies = [
 name = "ivm-exec"
 version = "0.0.1"
 dependencies = [
- "alloy",
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
  "alloy-network 0.9.2",
+ "alloy-primitives",
  "alloy-rpc-types",
  "alloy-signer-local 0.9.2",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", rev =
 reth-payload-validator = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-tasks = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 
 # revm needs to be kept in sync with reth
 revm = { version = "19.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,9 @@ reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "28
 reth-network = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-providers = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 
 # revm needs to be kept in sync with reth
 revm = { version = "19.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,9 +198,10 @@ reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "28
 reth-network = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
-reth-providers = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-payload-validator = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 
 # revm needs to be kept in sync with reth
 revm = { version = "19.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,13 +121,17 @@ significant_drop_tightening = "allow"
 # a
 anyhow = { version = "1", default-features = false }
 axum = { version = "0", features = ["http2", "tokio", "json"], default-features = false }
+# All alloy deps should be kept in sync with reth
 # only include features that we know can be compiled into zkvm program
 alloy = { version = "0.9.2", features = ["sol-types"], default-features = false }
-# Hacks to play happy with reth types, we normally use the alloy facade crate
+
 alloy-eips = { version = "0.9.2", default-features = false }
 alloy-consensus = { version = "0.9.2"}
 alloy-signer-local = { version = "0.9.2"}
 alloy-network = { version = "0.9.2"}
+alloy-rpc-types = { version = "0.9.2" }
+
+
 
 # b
 bincode = { version = "1", default-features = false }
@@ -189,8 +193,13 @@ reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d523
 reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-network = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "28d5231", default-features = false }
 
-# alloy, revm reth need to be kept in sync
+# revm needs to be kept in sync with reth
 revm = { version = "19.2.0", default-features = false }
 revm-primitives = { version = "15.1.0", default-features = false }
 revm-interpreter = { version = "15.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,14 +124,15 @@ axum = { version = "0", features = ["http2", "tokio", "json"], default-features 
 # All alloy deps should be kept in sync with reth
 # only include features that we know can be compiled into zkvm program
 alloy = { version = "0.9.2", features = ["sol-types"], default-features = false }
-
+# for ivm-exec, we don't use the alloy facade crate
 alloy-eips = { version = "0.9.2", default-features = false }
-alloy-consensus = { version = "0.9.2"}
+alloy-consensus = { version = "0.9.2" }
 alloy-signer-local = { version = "0.9.2"}
 alloy-network = { version = "0.9.2"}
 alloy-rpc-types = { version = "0.9.2" }
-
-
+alloy-primitives = { version = "0.8.15", default-features = false, features = [
+    "map-foldhash",
+] }
 
 # b
 bincode = { version = "1", default-features = false }

--- a/bin/exec/Cargo.toml
+++ b/bin/exec/Cargo.toml
@@ -29,8 +29,8 @@ reth-provider = { workspace = true }
 reth-ethereum-cli = { workspace = true }
 
 alloy-rpc-types = { workspace = true }
+alloy-primitives = { workspace = true }
 
-alloy = { workspace = true, features = ["genesis"] }
 eyre = { workspace = true  }
 tokio = { workspace = true }
 tracing = { workspace = true }
@@ -40,7 +40,6 @@ serde = { workspace = true }
 
 [dev-dependencies]
 reth-provider = { workspace = true, features = ["test-utils"] }
-alloy = { workspace = true, features = ["consensus", "signer-local", "network"] }
 revm = { workspace = true }
 k256 = { workspace = true }
 

--- a/bin/exec/Cargo.toml
+++ b/bin/exec/Cargo.toml
@@ -8,6 +8,8 @@ version.workspace = true
 workspace = true
 
 [dependencies]
+# only use reth for CLI
+reth = { workspace = true }
 reth-node-builder = { workspace = true }
 reth-node-ethereum = { workspace = true }
 reth-evm-ethereum = { workspace = true }
@@ -20,9 +22,11 @@ reth-revm = { workspace = true }
 reth-network = { workspace = true }
 reth-rpc = { workspace = true }
 reth-primitives = { workspace = true }
-reth-providers = { workspace = true }
 reth-transaction-pool = { workspace = true }
 reth-payload-validator = { workspace = true }
+reth-tasks = { workspace = true }
+reth-provider = { workspace = true }
+reth-ethereum-cli = { workspace = true }
 
 alloy-rpc-types = { workspace = true }
 

--- a/bin/exec/Cargo.toml
+++ b/bin/exec/Cargo.toml
@@ -20,6 +20,9 @@ reth-revm = { workspace = true }
 reth-network = { workspace = true }
 reth-rpc = { workspace = true }
 reth-primitives = { workspace = true }
+reth-providers = { workspace = true }
+reth-transaction-pool = { workspace = true }
+reth-payload-validator = { workspace = true }
 
 alloy-rpc-types = { workspace = true }
 

--- a/bin/exec/Cargo.toml
+++ b/bin/exec/Cargo.toml
@@ -27,6 +27,7 @@ reth-payload-validator = { workspace = true }
 reth-tasks = { workspace = true }
 reth-provider = { workspace = true }
 reth-ethereum-cli = { workspace = true }
+reth-cli-util = { workspace = true }
 
 alloy-rpc-types = { workspace = true }
 alloy-primitives = { workspace = true }
@@ -51,9 +52,19 @@ alloy-signer-local = { workspace = true }
 alloy-network = { workspace = true }
 
 [features]
-default = ["min-trace-logs"]
+default = ["min-trace-logs", "asm-keccak", "jemalloc"]
+
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]
 min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
+
+asm-keccak = [
+	"reth-primitives/asm-keccak",
+	"alloy-primitives/asm-keccak"
+]
+
+jemalloc = [
+    "reth-cli-util/jemalloc",
+]

--- a/bin/exec/Cargo.toml
+++ b/bin/exec/Cargo.toml
@@ -8,13 +8,20 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-reth = { workspace = true, features = ["jemalloc", "asm-keccak"] }
+reth-node-builder = { workspace = true }
 reth-node-ethereum = { workspace = true }
 reth-evm-ethereum = { workspace = true }
 reth-ethereum-engine-primitives = { workspace = true }
 reth-node-api = { workspace = true }
 reth-evm = { workspace = true }
 reth-primitives-traits = { workspace = true }
+reth-chainspec = { workspace = true }
+reth-revm = { workspace = true }
+reth-network = { workspace = true }
+reth-rpc = { workspace = true }
+reth-primitives = { workspace = true }
+
+alloy-rpc-types = { workspace = true }
 
 alloy = { workspace = true, features = ["genesis"] }
 eyre = { workspace = true  }
@@ -26,7 +33,6 @@ serde = { workspace = true }
 
 [dev-dependencies]
 reth-provider = { workspace = true, features = ["test-utils"] }
-reth-revm = { workspace = true }
 alloy = { workspace = true, features = ["consensus", "signer-local", "network"] }
 revm = { workspace = true }
 k256 = { workspace = true }
@@ -40,8 +46,8 @@ alloy-network = { workspace = true }
 
 [features]
 default = ["min-trace-logs"]
-min-error-logs = ["reth/min-error-logs"]
-min-warn-logs = ["reth/min-warn-logs"]
-min-info-logs = ["reth/min-info-logs"]
-min-debug-logs = ["reth/min-debug-logs"]
-min-trace-logs = ["reth/min-trace-logs"]
+min-error-logs = ["tracing/release_max_level_error"]
+min-warn-logs = ["tracing/release_max_level_warn"]
+min-info-logs = ["tracing/release_max_level_info"]
+min-debug-logs = ["tracing/release_max_level_debug"]
+min-trace-logs = ["tracing/release_max_level_trace"]

--- a/bin/exec/src/config.rs
+++ b/bin/exec/src/config.rs
@@ -42,7 +42,7 @@ impl IvmConfig {
 #[cfg(test)]
 mod test {
     use super::IvmConfig;
-    use alloy::primitives::address;
+    use alloy_primitives::address;
     use std::collections::HashSet;
 
     #[test]

--- a/bin/exec/src/engine.rs
+++ b/bin/exec/src/engine.rs
@@ -1,17 +1,15 @@
 //! IVM Engine API validator.
 
-use reth::{
-    api::InvalidPayloadAttributesError,
-    builder::{
+use reth_node_api::InvalidPayloadAttributesError;
+use reth_node_builder::{
         rpc::EngineValidatorBuilder, AddOnsContext, EngineApiMessageVersion,
         EngineObjectValidationError, EngineTypes, EngineValidator, FullNodeComponents,
         NodeTypesWithEngine, PayloadOrAttributes, PayloadTypes, PayloadValidator,
-    },
-    chainspec::ChainSpec,
-    payload::ExecutionPayloadValidator,
-    primitives::{Block, EthPrimitives, SealedBlockFor},
-    rpc::types::engine::{ExecutionPayload, ExecutionPayloadSidecar, PayloadError},
-};
+    };
+use reth_chainspec::ChainSpec;
+use reth_payload_validator::ExecutionPayloadValidator;
+use reth_primitives::{Block, EthPrimitives, SealedBlockFor};
+use alloy_rpc_types::engine::{ExecutionPayload, ExecutionPayloadSidecar, PayloadError};
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_node_ethereum::{node::EthereumEngineValidator, EthEngineTypes};
 use std::sync::Arc;

--- a/bin/exec/src/engine.rs
+++ b/bin/exec/src/engine.rs
@@ -77,7 +77,7 @@ where
     fn validate_payload_attributes_against_header(
         &self,
         _attr: &<Types as PayloadTypes>::PayloadAttributes,
-        _header: &<Self::Block as reth::api::Block>::Header,
+        _header: &<Self::Block as reth_node_api::Block>::Header,
     ) -> Result<(), InvalidPayloadAttributesError> {
         // skip timestamp validation
         Ok(())

--- a/bin/exec/src/engine.rs
+++ b/bin/exec/src/engine.rs
@@ -1,17 +1,17 @@
 //! IVM Engine API validator.
 
+use alloy_rpc_types::engine::{ExecutionPayload, ExecutionPayloadSidecar, PayloadError};
+use reth_chainspec::ChainSpec;
+use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_node_api::InvalidPayloadAttributesError;
 use reth_node_builder::{
-        rpc::EngineValidatorBuilder, AddOnsContext, EngineApiMessageVersion,
-        EngineObjectValidationError, EngineTypes, EngineValidator, FullNodeComponents,
-        NodeTypesWithEngine, PayloadOrAttributes, PayloadTypes, PayloadValidator,
-    };
-use reth_chainspec::ChainSpec;
+    rpc::EngineValidatorBuilder, AddOnsContext, EngineApiMessageVersion,
+    EngineObjectValidationError, EngineTypes, EngineValidator, FullNodeComponents,
+    NodeTypesWithEngine, PayloadOrAttributes, PayloadTypes, PayloadValidator,
+};
+use reth_node_ethereum::{node::EthereumEngineValidator, EthEngineTypes};
 use reth_payload_validator::ExecutionPayloadValidator;
 use reth_primitives::{Block, EthPrimitives, SealedBlockFor};
-use alloy_rpc_types::engine::{ExecutionPayload, ExecutionPayloadSidecar, PayloadError};
-use reth_ethereum_engine_primitives::EthPayloadAttributes;
-use reth_node_ethereum::{node::EthereumEngineValidator, EthEngineTypes};
 use std::sync::Arc;
 
 /// Engine API validation logic for IVM.

--- a/bin/exec/src/evm/builder.rs
+++ b/bin/exec/src/evm/builder.rs
@@ -1,6 +1,6 @@
 //! Evm builder that includes custom logic for zero gas fee transactions.
 
-use reth::revm::{
+use reth_revm::{
     handler::register::EvmHandler,
     precompile::primitives::{EVMError, InvalidTransaction},
     primitives::{EnvWithHandlerCfg, TxKind},

--- a/bin/exec/src/evm/mod.rs
+++ b/bin/exec/src/evm/mod.rs
@@ -2,18 +2,16 @@
 
 use crate::evm::builder::IvmEvmBuilder;
 use alloy::primitives::{Address, Bytes};
-use reth::{
-    builder::{
-        components::ExecutorBuilder, BuilderContext, ConfigureEvm, FullNodeTypes,
-        NodeTypesWithEngine,
-    },
-    chainspec::ChainSpec,
-    primitives::{EthPrimitives, Header, TransactionSigned},
-    revm::{
+use reth_node_builder::{
+    components::ExecutorBuilder, BuilderContext, ConfigureEvm, FullNodeTypes,
+    NodeTypesWithEngine,
+};
+use reth_chainspec::ChainSpec;
+use reth_primitives::{EthPrimitives, Header, TransactionSigned};
+use reth_revm::{
         primitives::{CfgEnvWithHandlerCfg, Env, TxEnv},
         Database, Evm, GetInspector,
-    },
-};
+    };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{ConfigureEvmEnv, NextBlockEnvAttributes};
 use reth_node_ethereum::{BasicBlockExecutorProvider, EthExecutionStrategyFactory};

--- a/bin/exec/src/evm/mod.rs
+++ b/bin/exec/src/evm/mod.rs
@@ -2,19 +2,18 @@
 
 use crate::evm::builder::IvmEvmBuilder;
 use alloy_primitives::{Address, Bytes};
-use reth_node_builder::{
-    components::ExecutorBuilder, BuilderContext, ConfigureEvm, FullNodeTypes,
-    NodeTypesWithEngine,
-};
 use reth_chainspec::ChainSpec;
-use reth_primitives::{EthPrimitives, Header, TransactionSigned};
-use reth_revm::{
-        primitives::{CfgEnvWithHandlerCfg, Env, TxEnv},
-        Database, Evm, GetInspector,
-    };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{ConfigureEvmEnv, NextBlockEnvAttributes};
+use reth_node_builder::{
+    components::ExecutorBuilder, BuilderContext, ConfigureEvm, FullNodeTypes, NodeTypesWithEngine,
+};
 use reth_node_ethereum::{BasicBlockExecutorProvider, EthExecutionStrategyFactory};
+use reth_primitives::{EthPrimitives, Header, TransactionSigned};
+use reth_revm::{
+    primitives::{CfgEnvWithHandlerCfg, Env, TxEnv},
+    Database, Evm, GetInspector,
+};
 use std::{convert::Infallible, sync::Arc};
 
 pub mod builder;

--- a/bin/exec/src/evm/mod.rs
+++ b/bin/exec/src/evm/mod.rs
@@ -1,7 +1,7 @@
 //! Configuration for IVM's EVM execution environment.
 
 use crate::evm::builder::IvmEvmBuilder;
-use alloy::primitives::{Address, Bytes};
+use alloy_primitives::{Address, Bytes};
 use reth_node_builder::{
     components::ExecutorBuilder, BuilderContext, ConfigureEvm, FullNodeTypes,
     NodeTypesWithEngine,
@@ -112,7 +112,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloy::primitives::{hex, Address, TxKind, B256};
+    use alloy_primitives::{hex, Address, TxKind, B256};
     use k256::ecdsa::SigningKey;
     use reth::{
         chainspec::{ChainSpecBuilder, MAINNET},

--- a/bin/exec/src/lib.rs
+++ b/bin/exec/src/lib.rs
@@ -1,8 +1,8 @@
 //! IVM execution client types for plugging into reth node builder.
 
 use crate::engine::IvmEngineValidatorBuilder;
-use reth_node_builder::{rpc::RpcAddOns, FullNodeComponents, FullNodeTypes};
 use reth_network::NetworkHandle;
+use reth_node_builder::{rpc::RpcAddOns, FullNodeComponents, FullNodeTypes};
 use reth_rpc::eth::EthApi;
 use std::path::PathBuf;
 

--- a/bin/exec/src/lib.rs
+++ b/bin/exec/src/lib.rs
@@ -1,11 +1,9 @@
 //! IVM execution client types for plugging into reth node builder.
 
 use crate::engine::IvmEngineValidatorBuilder;
-use reth::{
-    builder::{rpc::RpcAddOns, FullNodeComponents, FullNodeTypes},
-    network::NetworkHandle,
-    rpc::eth::EthApi,
-};
+use reth_node_builder::{rpc::RpcAddOns, FullNodeComponents, FullNodeTypes};
+use reth_network::NetworkHandle;
+use reth_rpc::eth::EthApi;
 use std::path::PathBuf;
 
 pub mod config;

--- a/bin/exec/src/main.rs
+++ b/bin/exec/src/main.rs
@@ -6,6 +6,7 @@ use ivm_exec::{
 };
 use reth::cli::Cli;
 use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
+use reth_node_builder::{engine_tree_config::TreeConfig, EngineNodeLauncher};
 use reth_node_ethereum::EthereumNode;
 
 const IVM_CONFIG_FILE: &str = "ivm_config.toml";
@@ -31,7 +32,14 @@ fn main() {
                     EthereumNode::components().pool(pool_builder).executor(IvmExecutorBuilder),
                 )
                 .with_add_ons(IvmAddOns::default())
-                .launch()
+                .launch_with_fn(|launch_builder| {
+                    let launcher = EngineNodeLauncher::new(
+                        launch_builder.task_executor().clone(),
+                        launch_builder.config().datadir(),
+                        TreeConfig::default(),
+                    );
+                    launch_builder.launch_with(launcher)
+                })
                 .await?;
 
             handle.wait_for_node_exit().await

--- a/bin/exec/src/main.rs
+++ b/bin/exec/src/main.rs
@@ -4,7 +4,8 @@ use clap::Parser;
 use ivm_exec::{
     config::IvmConfig, evm::IvmExecutorBuilder, pool::IvmPoolBuilder, IvmAddOns, IvmCliExt,
 };
-use reth::{chainspec::EthereumChainSpecParser, cli::Cli};
+use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
+use reth::cli::Cli;
 use reth_node_ethereum::EthereumNode;
 
 const IVM_CONFIG_FILE: &str = "ivm_config.toml";

--- a/bin/exec/src/pool/mod.rs
+++ b/bin/exec/src/pool/mod.rs
@@ -3,14 +3,14 @@
 
 use crate::pool::validator::{IvmTransactionAllowConfig, IvmTransactionValidator};
 
+use reth_chainspec::ChainSpec;
 use reth_node_api::NodeTypes;
 use reth_node_builder::{components::PoolBuilder, BuilderContext, FullNodeTypes};
-use reth_chainspec::ChainSpec;
 use reth_primitives::EthPrimitives;
 use reth_provider::CanonStateSubscriptions;
 use reth_transaction_pool::{
-    blobstore::DiskFileBlobStore, validate::EthTransactionValidatorBuilder,
-    CoinbaseTipOrdering, EthPooledTransaction, TransactionValidationTaskExecutor,
+    blobstore::DiskFileBlobStore, validate::EthTransactionValidatorBuilder, CoinbaseTipOrdering,
+    EthPooledTransaction, TransactionValidationTaskExecutor,
 };
 use tracing::{debug, info};
 
@@ -116,20 +116,19 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloy_primitives::{hex, U256};
     use alloy_eips::eip2718::Decodable2718;
+    use alloy_primitives::{hex, U256};
     use reth_chainspec::MAINNET;
     use reth_primitives::{
-        transaction::SignedTransactionIntoRecoveredExt, InvalidTransactionError,
-        PooledTransaction,
+        transaction::SignedTransactionIntoRecoveredExt, InvalidTransactionError, PooledTransaction,
     };
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_transaction_pool::{
         blobstore::InMemoryBlobStore,
         error::{InvalidPoolTransactionError, PoolErrorKind},
         CoinbaseTipOrdering, EthPooledTransaction, Pool, PoolTransaction, TransactionOrigin,
         TransactionPool, TransactionValidationOutcome,
     };
-    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use std::collections::HashSet;
 
     fn get_create_transaction() -> EthPooledTransaction {

--- a/bin/exec/src/pool/mod.rs
+++ b/bin/exec/src/pool/mod.rs
@@ -116,7 +116,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloy::primitives::{hex, U256};
+    use alloy_primitives::{hex, U256};
     use alloy_eips::eip2718::Decodable2718;
     use reth_chainspec::MAINNET;
     use reth_primitives::{

--- a/bin/exec/src/pool/mod.rs
+++ b/bin/exec/src/pool/mod.rs
@@ -2,16 +2,15 @@
 //! additional validation logic.
 
 use crate::pool::validator::{IvmTransactionAllowConfig, IvmTransactionValidator};
-use reth::{
-    api::NodeTypes,
-    builder::{components::PoolBuilder, BuilderContext, FullNodeTypes},
-    chainspec::ChainSpec,
-    primitives::EthPrimitives,
-    providers::CanonStateSubscriptions,
-    transaction_pool::{
-        blobstore::DiskFileBlobStore, validate::EthTransactionValidatorBuilder,
-        CoinbaseTipOrdering, EthPooledTransaction, TransactionValidationTaskExecutor,
-    },
+
+use reth_node_api::NodeTypes;
+use reth_node_builder::{components::PoolBuilder, BuilderContext, FullNodeTypes};
+use reth_chainspec::ChainSpec;
+use reth_primitives::EthPrimitives;
+use reth_providers::CanonStateSubscriptions;
+use reth_transaction_pool::{
+    blobstore::DiskFileBlobStore, validate::EthTransactionValidatorBuilder,
+    CoinbaseTipOrdering, EthPooledTransaction, TransactionValidationTaskExecutor,
 };
 use tracing::{debug, info};
 

--- a/bin/exec/src/pool/validator.rs
+++ b/bin/exec/src/pool/validator.rs
@@ -1,7 +1,7 @@
 //! IVM has a custom transaction validator that performs allow list checks on top of the standard
 //! ethereum transaction checks.
 
-use alloy::primitives::Address;
+use alloy_primitives::Address;
 use reth_primitives::{InvalidTransactionError, SealedBlock};
 use reth_provider::StateProviderFactory;
 use reth_tasks::TaskSpawner;
@@ -166,7 +166,7 @@ where
 #[cfg(test)]
 mod test {
     use super::IvmTransactionAllowConfig;
-    use alloy::primitives::Address;
+    use alloy_primitives::Address;
     use std::collections::HashSet;
 
     // Helpers to set/get values for tests

--- a/bin/exec/src/pool/validator.rs
+++ b/bin/exec/src/pool/validator.rs
@@ -2,15 +2,14 @@
 //! ethereum transaction checks.
 
 use alloy::primitives::Address;
-use reth::{
-    primitives::{InvalidTransactionError, SealedBlock},
-    providers::StateProviderFactory,
-    tasks::TaskSpawner,
-    transaction_pool::{
-        validate::ValidationTask, EthPoolTransaction, EthTransactionValidator, TransactionOrigin,
-        TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
-    },
+use reth_primitives::{InvalidTransactionError, SealedBlock};
+use reth_provider::StateProviderFactory;
+use reth_tasks::TaskSpawner;
+use reth_transaction_pool::{
+    validate::ValidationTask, EthPoolTransaction, EthTransactionValidator, TransactionOrigin,
+    TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
 };
+
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::Mutex;
 


### PR DESCRIPTION
Targets #443 

Changes:
- Don't use reth or alloy facade crates in ivm-exec
- Adds in the jemalloc setup from reth utils. I was noticing reth uses this, so I figured we might as well. But I can remove if not desirable. 