### PR TITLE
fix: exposes port 9100 and cleaner --copy

### DIFF
--- a/Dockerfile.coprocessor-node
+++ b/Dockerfile.coprocessor-node
@@ -28,6 +28,6 @@ RUN apt-get update && \
 
 COPY --from=builder /app/target/release/ivm-coproc /usr/local/bin/ivm-coproc
 COPY --from=grafana/promtail:3.0.0 /usr/bin/promtail /usr/local/bin
-COPY --from=prom/node-exporter:v1.8.2 /bin/node_exporter /usr/local/bin/node_exporter
+COPY --from=prom/node-exporter:v1.8.2 /bin/node_exporter /usr/local/bin
 
-EXPOSE 50069 50420 22
+EXPOSE 22 9100 50069 50420

--- a/Dockerfile.exec
+++ b/Dockerfile.exec
@@ -28,7 +28,7 @@ RUN apt-get update && \
 
 COPY --from=builder /app/target/release/ivm-exec /usr/local/bin/reth
 COPY --from=grafana/promtail:3.0.0 /usr/bin/promtail /usr/local/bin
-COPY --from=prom/node-exporter:v1.8.2 /bin/node_exporter /usr/local/bin/node_exporter
+COPY --from=prom/node-exporter:v1.8.2 /bin/node_exporter /usr/local/bin
 COPY entrypoint-exec.sh /usr/local/bin/entrypoint.sh
 
 RUN chmod +x /usr/local/bin/reth


### PR DESCRIPTION
# What

Exposes port `9100` on the coprocessor docker container