### PR TITLE
test: Add e2e test for parallel job submission

### DIFF
--- a/test/e2e/src/lib.rs
+++ b/test/e2e/src/lib.rs
@@ -36,6 +36,8 @@ pub struct Args {
     pub anvil: AnvilJobManager,
     /// Coprocessor Node gRPC client.
     pub coprocessor_node: CoprocessorNodeClient<Channel>,
+    /// Coprocessor Node gRPC endpoint.
+    pub coprocessor_node_endpoint: String,
     /// Handle for DB. Use with care.
     pub db: Arc<DatabaseEnv>,
 }
@@ -137,6 +139,7 @@ impl E2E {
         let mut args = Args {
             mock_consumer: None,
             coprocessor_node,
+            coprocessor_node_endpoint: cn_grpc_client_url.clone(),
             anvil,
             clob_consumer: None,
             clob_endpoint: None,

--- a/test/e2e/tests/mock_consumer.rs
+++ b/test/e2e/tests/mock_consumer.rs
@@ -219,11 +219,8 @@ async fn web2_parallel_job_submission_coprocessor_node_mock_consumer_e2e() {
 
         // Submit jobs to coproc node
         let mut join_set = JoinSet::new();
-        for (job_id, job_request) in &jobs {
+        for (job_id, job_request) in jobs.clone() {
             let endpoint = args.coprocessor_node_endpoint.clone();
-
-            let job_id = job_id.clone();
-            let job_request = job_request.clone();
             join_set.spawn(async move {
                 let mut coprocessor_node =
                     CoprocessorNodeClient::connect(endpoint.clone()).await.unwrap();


### PR DESCRIPTION
This test demonstrates an issue with job submission under concurrency. Before we roll out a fix, I wanted to prepare a PR that shows the problem. 

In the majority of test runs, the coprocessor stalls after relaying the first transaction. The reason is that we spawn one execution actor per gRPC call, when it should be only a single one.