### PR TITLE
chore(toolchain): use nightly-2025-01-11; run fmt

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,11 +3,12 @@ description: common setup for rust builds
 runs:
   using: "composite"
   steps:
-      - uses: dtolnay/rust-toolchain@1.83
+      - name: Install rust nightly toolchain with fmt
+        # Make sure to keep this in sync with the version in rust-toolchain.toml
+        uses: dtolnay/rust-toolchain@master
         with:
-          components: clippy
-
-      - uses: taiki-e/install-action@cargo-binstall
+          toolchain: nightly-2025-01-11
+          components: rustc rustfmt cargo clippy
 
       - name: Install sp1 tooling
         shell: bash

--- a/bin/exec/src/pool/validator.rs
+++ b/bin/exec/src/pool/validator.rs
@@ -235,9 +235,9 @@ where
 
         // Drop non-local transactions with a fee lower than the configured fee for acceptance into
         // the pool.
-        if !self.local_transactions_config.is_local(origin, transaction.sender_ref())
-            && transaction.is_eip1559()
-            && transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
+        if !self.local_transactions_config.is_local(origin, transaction.sender_ref()) &&
+            transaction.is_eip1559() &&
+            transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
         {
             return TransactionValidationOutcome::Invalid(
                 transaction,

--- a/bin/exec/src/pool/validator.rs
+++ b/bin/exec/src/pool/validator.rs
@@ -157,7 +157,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip2930Disabled.into(),
-                    )
+                    );
                 }
             }
             EIP1559_TX_TYPE_ID => {
@@ -166,7 +166,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip1559Disabled.into(),
-                    )
+                    );
                 }
             }
             EIP4844_TX_TYPE_ID => {
@@ -175,7 +175,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip4844Disabled.into(),
-                    )
+                    );
                 }
             }
             EIP7702_TX_TYPE_ID => {
@@ -184,7 +184,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip7702Disabled.into(),
-                    )
+                    );
                 }
             }
 
@@ -202,13 +202,13 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::OversizedData(tx_input_len, self.max_tx_input_bytes),
-            )
+            );
         }
 
         // Check whether the init code size has been exceeded.
         if self.fork_tracker.is_shanghai_activated() {
             if let Err(err) = transaction.ensure_max_init_code_size(MAX_INIT_CODE_BYTE_SIZE) {
-                return TransactionValidationOutcome::Invalid(transaction, err)
+                return TransactionValidationOutcome::Invalid(transaction, err);
             }
         }
 
@@ -222,7 +222,7 @@ where
                     transaction_gas_limit,
                     block_gas_limit,
                 ),
-            )
+            );
         }
 
         // Ensure max_priority_fee_per_gas (if EIP1559) is less than max_fee_per_gas if any.
@@ -230,19 +230,19 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::TipAboveFeeCap.into(),
-            )
+            );
         }
 
         // Drop non-local transactions with a fee lower than the configured fee for acceptance into
         // the pool.
-        if !self.local_transactions_config.is_local(origin, transaction.sender_ref()) &&
-            transaction.is_eip1559() &&
-            transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
+        if !self.local_transactions_config.is_local(origin, transaction.sender_ref())
+            && transaction.is_eip1559()
+            && transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
         {
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::Underpriced,
-            )
+            );
         }
 
         // Checks for chainid
@@ -251,7 +251,7 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::ChainIdMismatch.into(),
-                )
+                );
             }
         }
 
@@ -261,19 +261,19 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::TxTypeNotSupported.into(),
-                )
+                );
             }
 
             if transaction.authorization_count() == 0 {
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     Eip7702PoolTransactionError::MissingEip7702AuthorizationList.into(),
-                )
+                );
             }
         }
 
         if let Err(err) = ensure_intrinsic_gas(&transaction, &self.fork_tracker) {
-            return TransactionValidationOutcome::Invalid(transaction, err)
+            return TransactionValidationOutcome::Invalid(transaction, err);
         }
 
         // light blob tx pre-checks
@@ -283,7 +283,7 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::TxTypeNotSupported.into(),
-                )
+                );
             }
 
             let blob_count = transaction.blob_count();
@@ -294,7 +294,7 @@ where
                     InvalidPoolTransactionError::Eip4844(
                         Eip4844PoolTransactionError::NoEip4844Blobs,
                     ),
-                )
+                );
             }
 
             if blob_count > MAX_BLOBS_PER_BLOCK {
@@ -307,7 +307,7 @@ where
                             permitted: MAX_BLOBS_PER_BLOCK,
                         },
                     ),
-                )
+                );
             }
         }
 
@@ -358,7 +358,7 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::SignerAccountHasBytecode.into(),
-                )
+                );
             }
         }
 
@@ -370,7 +370,7 @@ where
                 transaction,
                 InvalidTransactionError::NonceNotConsistent { tx: tx_nonce, state: account.nonce }
                     .into(),
-            )
+            );
         }
 
         // This is where balance is normally checked
@@ -387,7 +387,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::TxTypeNotSupported.into(),
-                    )
+                    );
                 }
                 EthBlobTransactionSidecar::Missing => {
                     // This can happen for re-injected blob transactions (on re-org), since the blob
@@ -402,7 +402,7 @@ where
                             InvalidPoolTransactionError::Eip4844(
                                 Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
                             ),
-                        )
+                        );
                     }
                 }
                 EthBlobTransactionSidecar::Present(blob) => {
@@ -413,7 +413,7 @@ where
                             InvalidPoolTransactionError::Eip4844(
                                 Eip4844PoolTransactionError::InvalidEip4844Blob(err),
                             ),
-                        )
+                        );
                     }
                     // store the extracted blob
                     maybe_blob_sidecar = Some(blob);

--- a/crates/coproc/src/cli.rs
+++ b/crates/coproc/src/cli.rs
@@ -171,7 +171,7 @@ impl Opts {
     }
 
     fn signer_from_hex(secret: &String) -> Result<K256LocalSigner, Error> {
-        if secret.as_bytes().len() < 64 {
+        if secret.len() < 64 {
             return Err(Error::ShortPrivateKeyHex);
         }
 

--- a/crates/coproc/src/event.rs
+++ b/crates/coproc/src/event.rs
@@ -106,7 +106,6 @@ where
                         } else {
                             warn!(?sleep_millis, "retrying creating ws connection to rpc");
                         }
-                        continue;
                     }
                 }
             };

--- a/crates/coproc/src/execute.rs
+++ b/crates/coproc/src/execute.rs
@@ -99,7 +99,6 @@ impl ExecutionActor {
                         },
                         None => {
                             warn!("execute actor channel closed");
-                            continue
                         },
                     }
                 }
@@ -143,7 +142,6 @@ impl ExecutionActor {
                             break;
                         } else {
                             // The channel is still open, so we continue to wait for new messages
-                            continue;
                         },
                     }
                 }

--- a/examples/clob/node/src/batcher.rs
+++ b/examples/clob/node/src/batcher.rs
@@ -43,7 +43,6 @@ where
         } else {
             debug!("waiting for the first request to be processed before starting batcher");
             sleep(Duration::from_millis(1_0000)).await;
-            continue;
         }
     }
 

--- a/examples/clob/node/src/event.rs
+++ b/examples/clob/node/src/event.rs
@@ -54,7 +54,6 @@ where
                     provider_retry += 1;
                 }
                 debug!(?sleep_millis, "retrying creating ws connection");
-                continue;
             }
         }
     };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.83.0"
+# Make sure to keep this in sync with the CI in .github/actions/setup/actions.yml
+channel = "nightly-2025-01-11"
 components = ["rustc", "rust-src", "rust-docs", "rustfmt", "rust-analyzer", "cargo", "clippy" ]


### PR DESCRIPTION
I kept getting diffs when running `cargo fmt` vs `cargo +nightly fmt`. The way I generated this diff was by running `cargo fmt`, pinning the toolchain, and then re-running `cargo fmt`.