### PR TITLE
feat(coproc): compress offchain input before blob enconding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,6 +4991,7 @@ dependencies = [
  "ivm-eip4844",
  "ivm-proto",
  "ivm-zkvm",
+ "lz4_flex",
  "thiserror 1.0.69",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,8 @@ k256 = { version = "0.13", default-features = false }
 kairos-trie = { git = "https://github.com/cspr-rad/kairos-trie.git", features = ["serde"] }
 
 # l
+lz4_flex = { version = "0.11", default-features = false }
+
 # m
 # n
 num_cpus = { version = "1" }

--- a/crates/zkvm-executor/Cargo.toml
+++ b/crates/zkvm-executor/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 tracing = { workspace = true }
 alloy = { workspace = true, features = ["signers"] }
 thiserror = { workspace = true }
+lz4_flex = { workspace = true }
 
 ivm-proto = { workspace = true }
 ivm-zkvm = { workspace = true }

--- a/crates/zkvm-executor/src/service.rs
+++ b/crates/zkvm-executor/src/service.rs
@@ -137,8 +137,9 @@ where
             .map_err(Error::ZkvmExecuteFailed)?;
 
         let sidecar = if !offchain_input.is_empty() {
+            let compressed_offchain_input = lz4_flex::block::compress_prepend_size(&offchain_input);
             let sidecar_builder: SidecarBuilder<SimpleCoder> =
-                std::iter::once(offchain_input).collect();
+                std::iter::once(compressed_offchain_input).collect();
             Some(sidecar_builder.build()?)
         } else {
             None


### PR DESCRIPTION
Closes #475 

This is a breaking change for any one consuming coproc blob data

I chose lz4 because, from what I understood, the compressed data will likely be smaller then snappy