### PR TITLE
fix(coproc): validate compressed data length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4787,6 +4787,7 @@ dependencies = [
  "ivm-tracing",
  "ivm-zkvm-executor",
  "k256",
+ "lz4_flex",
  "num_cpus",
  "prometheus",
  "reth-db",

--- a/crates/coproc/Cargo.toml
+++ b/crates/coproc/Cargo.toml
@@ -26,6 +26,7 @@ axum = { workspace = true }
 flume = { workspace = true }
 num_cpus = { workspace = true }
 url = { workspace = true }
+lz4_flex = { workspace = true }
 
 ivm-contracts = { workspace = true }
 ivm-abi = { workspace = true }


### PR DESCRIPTION
Follow up to #476. We want to validate compressed data length, else risk rejecting offchain input that would be valid once compressed.