### PR TITLE
Removes node_exporter and entrypoint.sh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,4 +14,3 @@
 !Cargo.lock
 !Cargo.toml
 !.cargo
-!entrypoint*

--- a/Dockerfile.coproc
+++ b/Dockerfile.coproc
@@ -28,6 +28,5 @@ RUN apt-get update && \
 
 COPY --from=builder /app/target/release/ivm-coproc /usr/local/bin/ivm-coproc
 COPY --from=grafana/promtail:3.0.0 /usr/bin/promtail /usr/local/bin
-COPY --from=prom/node-exporter:v1.8.2 /bin/node_exporter /usr/local/bin
 
-EXPOSE 22 9100 50069 50420
+EXPOSE 22 50069 50420

--- a/Dockerfile.exec
+++ b/Dockerfile.exec
@@ -28,12 +28,9 @@ RUN apt-get update && \
 
 COPY --from=builder /app/target/release/ivm-exec /usr/local/bin/reth
 COPY --from=grafana/promtail:3.0.0 /usr/bin/promtail /usr/local/bin
-COPY --from=prom/node-exporter:v1.8.2 /bin/node_exporter /usr/local/bin
-COPY entrypoint-exec.sh /usr/local/bin/entrypoint.sh
 
 RUN chmod +x /usr/local/bin/reth
-RUN chmod +x /usr/local/bin/entrypoint.sh
 
-EXPOSE  8545 8546 9001 9100 30303 30303/udp 
+EXPOSE  8545 8546 9001 30303 30303/udp 
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/reth"]

--- a/entrypoint-exec.sh
+++ b/entrypoint-exec.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-node_exporter &
-
-exec /usr/local/bin/reth


### PR DESCRIPTION
# What

We had included node_exporter into to running container when we were running via terraform. Now that this is deployed into K8s we are getting these metrics from kubelet directly for all of our pods.
We don't need node_exporter to be directly included anymore.