### PR TITLE
chore(ivm-exec): add fork for 2025.2.5

### DIFF
--- a/bin/exec/src/config/mod.rs
+++ b/bin/exec/src/config/mod.rs
@@ -133,7 +133,7 @@ impl IvmConfig {
     pub fn from_network(network: Network) -> Self {
         match network {
             Network::Suzuka => {
-                let addresses = vec![
+                let addresses0 = vec![
                     address!("0x7e480b98e3710753ffb23f67bd35391d5a6b1e9e"),
                     address!("0x17877a771f877d66317146c2158a13454c836d66"),
                     address!("0x088d6345341b686cbd765bfb6be49d96b1977bc4"),
@@ -147,12 +147,38 @@ impl IvmConfig {
 
                 let mut fork0 = IvmTransactionAllowConfig::deny_all();
                 let mut priority_senders = HashSet::new();
-                for addr in addresses {
+                for addr in addresses0 {
                     fork0.add_sender(addr);
                     fork0.add_to(addr);
+                }
+
+                let address1 = vec![
+                    address!("0x3361cddEa38de48e38a78D0c8E147c4b068ee710"), // spammer 1
+                    address!("0xa313C490a588FFe561591b7B80232297599A5346"), // spammer 2
+                    address!("0xA8D785806B05cF7253e18E3ddad7a214Fd2313b4"), // spammer 3
+                    address!("0xe6c32783830667d1a40c746bc2487d609aabe2c2"), // deployer
+                    address!("0xb99f5f26be2e689b0d4e0de99b59bed3655337c1"), // faucet
+                    address!("0x57dbd91b33eed2624cbbbb0b3f06d3ac68586f02"), // fee_recipient
+                    address!("0x62cf21043ac6b0da1cf255d64894db00bf5480d5"), // fuzzer
+                    address!("0xe76e63ed207f58ad51846d9748b6832d87b4d563"), // offchain_signer
+                    address!("0xff78fd33b2df47f64346b2ad3ee93798ff1e33aa"), // validator 0
+                    address!("0xde4499102af723d2dfc31c40e41b6a02bb860008"), // validator 1
+                    address!("0x9601d991a71d975dfcbc3e09bbb27e7552cdf10c"), // validator 2
+                    address!("0x46233286b1a41f9d9fe22ca36347396f34582fb3"), // validator 3
+                    address!("0x20f33ce90a13a4b5e7697e3544c3083b8f8a51d4"), // depositor
+                ];
+
+                let mut fork1 = IvmTransactionAllowConfig::deny_all();
+                for addr in address1 {
+                    fork1.add_sender(addr);
+                    fork1.add_to(addr);
                     priority_senders.insert(addr);
                 }
-                let forks = BTreeMap::from([(0, fork0)]);
+                let forks = BTreeMap::from([
+                    (0, fork0),          // genesis
+                    (1738731600, fork1), // february 5, 2025 00:00:00 UTC
+                ]);
+
                 Self { forks, priority_senders }
             }
         }


### PR DESCRIPTION
Essentially the same as #499, but just using the timestamp based forking so we can sanity check it works in prod.