### PR TITLE
fix: Add storage gaps in base coproc contracts

### DIFF
--- a/contracts/src/clob/ClobConsumer.sol
+++ b/contracts/src/clob/ClobConsumer.sol
@@ -52,6 +52,8 @@ contract ClobConsumer is StatefulConsumer, SingleOffchainSigner {
     mapping(address => uint256) public freeBalanceQuote;
     mapping(address => uint256) public lockedBalanceBase;
     mapping(address => uint256) public lockedBalanceQuote;
+    // Storage gap for upgradeability.
+    uint256[42] private __GAP;
 
     constructor() StatefulConsumer() SingleOffchainSigner() {
         _disableInitializers();

--- a/contracts/src/coprocessor/Consumer.sol
+++ b/contracts/src/coprocessor/Consumer.sol
@@ -18,6 +18,9 @@ abstract contract Consumer is
     
     mapping(bytes32 => JobInputs) internal jobIDToInputs;
 
+    // Storage gap for upgradeability.
+    uint256[47] private __GAP;
+
     function initialize(address initialOwner, address jobManager, uint64 initialMaxNonce) public virtual onlyInitializing {
         _transferOwnership(initialOwner);
         _jobManager = JobManager(jobManager);

--- a/contracts/src/coprocessor/OffchainRequester.sol
+++ b/contracts/src/coprocessor/OffchainRequester.sol
@@ -9,6 +9,9 @@ abstract contract OffchainRequester is Initializable, OwnableUpgradeable {
 
     bytes4 constant internal INVALID_SIGNATURE = 0xffffffff;
 
+    // Storage gap for upgradeability.
+    uint256[50] private __GAP;
+
     // EIP-1271
     function isValidSignature(bytes32 hash, bytes memory signature) public virtual view returns (bytes4);
 }

--- a/contracts/src/coprocessor/SingleOffchainSigner.sol
+++ b/contracts/src/coprocessor/SingleOffchainSigner.sol
@@ -10,6 +10,8 @@ import {console} from "forge-std/console.sol";
 // SingleOffchainSigner allows a single offchainSigner address to sign all offchain job requests
 abstract contract SingleOffchainSigner is OffchainRequester {
     address private offchainSigner;
+    // Storage gap for upgradeability.
+    uint256[49] private __GAP;
 
     function initialize(address _offchainSigner) public virtual onlyInitializing {
         offchainSigner = _offchainSigner;

--- a/contracts/src/coprocessor/StatefulConsumer.sol
+++ b/contracts/src/coprocessor/StatefulConsumer.sol
@@ -19,6 +19,8 @@ abstract contract StatefulConsumer is Consumer {
     }
 
     bytes32 public latestStateRoot;
+    // Storage gap for upgradeability.
+    uint256[49] private __GAP;
 
     function initialize(
         address initialOwner,


### PR DESCRIPTION
# What

- Adds storage gaps in the base coproc contracts like `SingleOffchainSigner` and `StatefulConsumer`
