### PR TITLE
feat: allow overwriting job

### DIFF
--- a/crates/coproc/src/intake.rs
+++ b/crates/coproc/src/intake.rs
@@ -165,7 +165,7 @@ where
             if self.get_pending_nonces(consumer_address).await?.contains(&job.nonce) {
                 return Ok(())
             }
-            
+
             // We overwrite the old job. This allows users to submit new jobs in case the original
             // job had an issue
             if old_job != job {
@@ -230,11 +230,8 @@ where
     }
 
     async fn write_pending_job(&self, job: &mut Job) {
-        job.status = JobStatus {
-            status: JobStatusType::Pending as i32,
-            failure_reason: None,
-            retries: 0,
-        };
+        job.status =
+            JobStatus { status: JobStatusType::Pending as i32, failure_reason: None, retries: 0 };
         let (tx, db_write_complete_rx) = oneshot::channel();
         self.writer_tx
             .send((Write::JobTable(job.clone()), Some(tx)))

--- a/crates/coproc/src/server.rs
+++ b/crates/coproc/src/server.rs
@@ -83,9 +83,10 @@ where
         // [ref: https://github.com/InfinityVM/InfinityVM/issues/168]
 
         info!(
-            job_id = hex::encode(job_id),
-            consumer = hex::encode(consumer),
             nonce,
+            consumer = hex::encode(consumer),
+            program_id = hex::encode(&program_id),
+            job_id = hex::encode(job_id),
             "new job request"
         );
 

--- a/crates/db/src/tables.rs
+++ b/crates/db/src/tables.rs
@@ -34,7 +34,7 @@ macro_rules! impl_compress_decompress {
     };
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 /// Request type for a job
 pub enum RequestType {
     /// Onchain job request (originating from contracts)

--- a/crates/db/src/tables.rs
+++ b/crates/db/src/tables.rs
@@ -34,7 +34,7 @@ macro_rules! impl_compress_decompress {
     };
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 /// Request type for a job
 pub enum RequestType {
     /// Onchain job request (originating from contracts)
@@ -44,7 +44,7 @@ pub enum RequestType {
 }
 
 /// Job used internally and stored in DB
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Job {
     /// The job ID (hash of nonce and consumer address)
     pub id: [u8; 32],


### PR DESCRIPTION
Prior to this job, if there is an error with a job a consumer has no way to overwrite that nonce. This updates the logic to always overwrite an old with a newer job with the same nonce, if they are not equal