### PR TITLE
fix: Increase histogram range of job execution times

### DIFF
--- a/crates/coproc/src/metrics.rs
+++ b/crates/coproc/src/metrics.rs
@@ -32,10 +32,10 @@ impl Metrics {
         let relayed_total = Counter::new("relayed_total", "Total number of jobs relayed").unwrap();
         let job_exec_time = Histogram::with_opts(
             HistogramOpts::new("job_exec_time", "Total time for a single job to execute").buckets(
-                // From 250ms to 100s, polynomial
+                // From 250ms to 3 minutes, polynomial
                 vec![
                     0.25, 1., 2.25, 4., 6., 9., 12., 16., 20., 25., 30., 36., 42., 49., 56., 64.,
-                    72., 81., 90., 100.,
+                    72., 81., 90., 100., 110., 121., 131., 144., 156., 169., 180.,
                 ],
             ),
         )

--- a/crates/coproc/src/metrics.rs
+++ b/crates/coproc/src/metrics.rs
@@ -32,10 +32,10 @@ impl Metrics {
         let relayed_total = Counter::new("relayed_total", "Total number of jobs relayed").unwrap();
         let job_exec_time = Histogram::with_opts(
             HistogramOpts::new("job_exec_time", "Total time for a single job to execute").buckets(
-                // From 562.5ms to 16s, polynomial
+                // From 250ms to 100s, polynomial
                 vec![
-                    0.5625, 1., 1.5625, 2.25, 3.0625, 4., 5.0625, 6.25, 7.5625, 9., 10.5625, 12.25,
-                    14.0625, 16.,
+                    0.25, 1., 2.25, 4., 6., 9., 12., 16., 20., 25., 30., 36., 42., 49., 56., 64.,
+                    72., 81., 90., 100.,
                 ],
             ),
         )


### PR DESCRIPTION
The new histogram for job execution times goes up to 3 minutes now.